### PR TITLE
[#142] - Limita cantidad de párrafos obtenidos en endpoint getLatest

### DIFF
--- a/api/story/latest.js
+++ b/api/story/latest.js
@@ -27,7 +27,7 @@ export default async function getLatest(req, res) {
                             forewords,
                             categories,
                             publishedAt,
-                            body,
+                            body[0...2],
                             review,
                             forewords,
                             'author': author-> { ..., nationality-> }


### PR DESCRIPTION
# Resumen
Se agrega selección desde el párrafo 0 al 2 para el fetch del endpoint latest.