### PR TITLE
[#162] - Agregar tsconfig.json para funciones serverless 

### DIFF
--- a/api/_utils/functions.ts
+++ b/api/_utils/functions.ts
@@ -1,7 +1,7 @@
-import { client } from './_helpers/sanity-connector';
+import { client } from '../_helpers/sanity-connector';
 import { SanityImageSource } from '@sanity/image-url/lib/types/types';
-import { AuthorDAO } from './_models/author-dao.model';
-import { ForewordDAO } from './_models/story-dao.model';
+import { AuthorDAO } from '../_models/author-dao.model';
+import { ForewordDAO } from '../_models/story-dao.model';
 import imageUrlBuilder from '@sanity/image-url';
 
 export function mapAuthor(authorDAO: AuthorDAO) {

--- a/api/story/[slug].ts
+++ b/api/story/[slug].ts
@@ -1,4 +1,4 @@
-import { mapAuthor, mapPrologues } from '../functions';
+import { mapAuthor, mapPrologues } from '../_utils/functions';
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { client } from '../_helpers/sanity-connector';
 

--- a/api/story/latest.ts
+++ b/api/story/latest.ts
@@ -1,4 +1,4 @@
-import { mapAuthor, mapPrologues } from '../functions';
+import { mapAuthor, mapPrologues } from '../_utils/functions';
 import { client } from '../_helpers/sanity-connector';
 import { VercelRequest, VercelResponse } from '@vercel/node';
 import { StoryDAO } from '../_models/story-dao.model';

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
# Resumen
* Agrega archivo tsconfig.json mínimo en `/api`
  * Se agrega en `true` el flag `allowSyntheticDefaultImports`
* Se mueve el archivo `functions.ts` a la carpeta `/api/utils`