### PR TITLE
[#164] - Eliminar propiedad day de aplicación

### DIFF
--- a/api/_helpers/environment.ts
+++ b/api/_helpers/environment.ts
@@ -9,6 +9,7 @@ if (!!result && !('error' in result)) {
         sanity: {
             projectId: result['SANITY_PROJECT_ID'],
             dataset: result['SANITY_DATASET'],
+            token: result['SANITY_TOKEN'],
         },
     };
 } else {
@@ -18,6 +19,7 @@ if (!!result && !('error' in result)) {
         sanity: {
             projectId: process.env['SANITY_PROJECT_ID'] as string,
             dataset: process.env['SANITY_DATASET'] as string,
+            token: result['SANITY_TOKEN'],
         },
     };
 }
@@ -26,6 +28,7 @@ export interface EnvironmentConfig {
     oneSignalAppId?: string;
     production: boolean;
     sanity: {
+        token: string;
         projectId: string;
         dataset: string;
     };

--- a/api/_helpers/sanity-connector.ts
+++ b/api/_helpers/sanity-connector.ts
@@ -4,6 +4,7 @@ import { environment } from './environment';
 export const client: SanityClient = sanityClient({
     projectId: environment.sanity.projectId,
     dataset: environment.sanity.dataset,
-    apiVersion: '2019-01-29', // use current UTC date - see "specifying API version"!
+    token: environment.sanity.token,
+    apiVersion: '2023-03-01', // use current UTC date - see "specifying API version"!
     useCdn: environment.production, // `false` if you want to ensure fresh data
 });

--- a/api/story/[slug].ts
+++ b/api/story/[slug].ts
@@ -7,7 +7,6 @@ export default async function getBySlug(req: VercelRequest, res: VercelResponse)
     const query = `*[_type == 'story' && slug.current == '${slug}']
                           {
                               title, 
-                              day, 
                               originalLink, 
                               forewords, 
                               categories, 

--- a/api/story/latest.ts
+++ b/api/story/latest.ts
@@ -33,7 +33,7 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
                             forewords,
                             approximateReadingTime,
                             'author': author-> { ..., nationality-> }
-                        } | [${(-amount)-1}..-1]
+                        } | [${(-amount)}..-1]
                     }`;
 
     const result = await client.fetch(query, {});

--- a/api/story/latest.ts
+++ b/api/story/latest.ts
@@ -19,11 +19,11 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
                         description,
                         language,
                         editionPrefix,
+                        'count': count(stories[]),
                         'stories': stories[]->{
                             _id,
                             'slug': slug.current,
                             title,
-                            day,
                             originalLink,
                             forewords,
                             categories,
@@ -33,7 +33,7 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
                             forewords,
                             approximateReadingTime,
                             'author': author-> { ..., nationality-> }
-                        } | order(day desc)[0...${amount}]
+                        } | [${(-amount)-1}..-1]
                     }`;
 
     const result = await client.fetch(query, {});
@@ -51,7 +51,7 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
             paragraphs: story.body,
             author: mapAuthor(story.author),
             prologues: mapPrologues(story.forewords),
-        })),
+        })).reverse(),
     };
 
     res.json(storylist);

--- a/api/story/original-links.ts
+++ b/api/story/original-links.ts
@@ -2,7 +2,7 @@ import { client } from '../_helpers/sanity-connector';
 import {VercelRequest, VercelResponse} from '@vercel/node';
 
 export default async function get(req: VercelRequest, res: VercelResponse) {
-    const query = `*[_type == 'story'] | order(day desc) {title, day, author->, originalLink}`;
+    const query = `*[_type == 'story'] {title, author->, originalLink}`;
     const result = await client.fetch(query, {});
     res.json(result);
 }

--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -10,12 +10,6 @@ export default {
             validation: (Rule) => Rule.required(),
         },
         {
-            name: 'day',
-            title: 'Día',
-            type: 'number',
-            validation: (Rule) => Rule.required(),
-        },
-        {
             name: 'slug',
             title: 'Slug',
             type: 'slug',

--- a/cms/scripts/deleteDayPropertyInStory.ts
+++ b/cms/scripts/deleteDayPropertyInStory.ts
@@ -1,0 +1,44 @@
+// RO - 2023-25-03
+// Este script fue utilizado el 25/03/2023 para eliminar el campo day de los documentos de tipo Story en Sanity CMS.
+// Queda aquí a modo de ejemplo para saber cómo proceder a la hora de escribir otro script de migración a futuro.
+
+import { client } from '../../api/_helpers/sanity-connector';
+
+const fetchStories = () =>
+    client.fetch(`
+  *[_type == 'story']
+`);
+
+const buildPatches = (stories) =>
+    stories.map((story) => ({
+        id: story._id,
+        patch: {
+            unset: ['day'],
+            ifRevisionID: story._rev,
+        },
+    }));
+
+const createTransaction = (patches) =>
+    patches.reduce((tx, patch) => tx.patch(patch.id, patch.patch), client.transaction());
+
+const commitTransaction = (tx) => tx.commit();
+
+const migrateBatch = async () => {
+    const stories = await fetchStories();
+    const patches = buildPatches(stories);
+    if (patches.length === 0) {
+        console.log('No hay documentos para migrar!');
+        return null;
+    }
+    console.log(
+        `Migrando batch:\n %s`,
+        patches.map((patch) => `${patch.id} => ${JSON.stringify(patch.patch)}`).join('\n')
+    );
+    const transaction = createTransaction(patches);
+    await commitTransaction(transaction);
+};
+
+migrateBatch().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/app/components/story-card/story-card.component.ts
+++ b/src/app/components/story-card/story-card.component.ts
@@ -11,12 +11,13 @@ export class StoryCardComponent implements OnInit {
     @Input() editionSuffix: string | undefined;
     @Input() displayDate: boolean = false;
     @Input() story: Story | undefined;
+    @Input() editionIndex: number = 0;
 
     editionLabel: string = '';
 
     ngOnInit() {
-        this.editionLabel = this.editionPrefix + ' ' + this.story?.day + ' - ' + this.story?.publishedAt;
-        this.editionLabel = `${this.editionPrefix} ${this.story?.day} ${
+        this.editionLabel = this.editionPrefix + ' ' + this.editionIndex + ' - ' + this.story?.publishedAt;
+        this.editionLabel = `${this.editionPrefix} ${this.editionIndex} ${
             this.displayDate ? ' - ' + this.story?.publishedAt : ''
         }${this.editionSuffix ? ' | ' + this.editionSuffix : ''}`;
     }

--- a/src/app/components/story-list-card-deck/story-list-card-deck.component.html
+++ b/src/app/components/story-list-card-deck/story-list-card-deck.component.html
@@ -13,17 +13,21 @@
 </ng-container>
 
 <div class="stories-card-container" [ngClass]="{ 'highlight-first-row': highlightFirstRow }">
-    <ng-container *ngIf="!storylist">
+    <ng-container *ngIf="!storylist; else storylistTemplate">
         <cuentoneta-story-card *ngFor="let skeleton of dummyList"></cuentoneta-story-card>
     </ng-container>
-    <ng-container *ngFor="let story of storylist?.stories">
+</div>
+
+<ng-template #storylistTemplate>
+    <ng-container *ngFor="let story of storylist?.stories; let editionIndex = index">
         <a [routerLink]="['/story']"
            [queryParams]="{ slug: story?.slug, list: storylist?.slug }">
             <cuentoneta-story-card
                     [displayDate]="displayDates"
                     [editionPrefix]="storylist?.editionPrefix"
                     [story]="story"
+                    [editionIndex]="(storylist.count - editionIndex)"
             ></cuentoneta-story-card>
         </a>
     </ng-container>
-</div>
+</ng-template>

--- a/src/app/components/story-list-card-deck/story-list-card-deck.component.ts
+++ b/src/app/components/story-list-card-deck/story-list-card-deck.component.ts
@@ -14,7 +14,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 })
 export class StoryListCardDeckComponent implements OnInit {
     @Input() number: number = 6;
-    @Input() storylist: StoryList | undefined;
+    @Input() storylist!: StoryList;
     @Input() highlightFirstRow: boolean = false;
     @Input() displayTitle: boolean = true;
     @Input() displayDates: boolean = false;

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.html
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.html
@@ -6,12 +6,12 @@
     </header>
 
     <ng-container *ngIf="!!storyList; else bodySkeleton">
-        <ng-container *ngFor="let story of storyList.stories">
+        <ng-container *ngFor="let story of storyList.stories; let editionIndex = index">
             <a [routerLink]="['/story']" [queryParams]="{ slug: story.slug, list: storyList.slug }">
                 <article>
                     <cuentoneta-story-edition-date-label
                         class="edition-and-label"
-                        [label]="getEditionLabel(story)"
+                        [label]="getEditionLabel(story, storyList.count - editionIndex)"
                     ></cuentoneta-story-edition-date-label>
                     <h4 class="title">{{ story.title }}</h4>
                     <h5 class="author">{{ story.author.name }}</h5>

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -8,12 +8,12 @@ import { Story } from '../../models/story.model';
     styleUrls: ['./story-navigation-bar.component.scss'],
 })
 export class StoryNavigationBarComponent {
-    @Input() storyList: StoryList | undefined = { title: '', slug: '', stories: [], editionPrefix: 'Edición' };
+    @Input() storyList!: StoryList;
 
     dummyList: null[] = Array(10);
 
     // ToDo: Separar card de cada cuento de la lista en su propio componente, para evitar usar un método en el template
-    getEditionLabel(story: Story): string {
-        return `${this.storyList?.editionPrefix} ${story.day} - ${story.publishedAt}`;
+    getEditionLabel(story: Story, editionIndex: number = 0): string {
+        return `${this.storyList?.editionPrefix} ${editionIndex} - ${story.publishedAt}`;
     }
 }

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -6,7 +6,6 @@ export interface Story {
     author: Author;
     title: string;
     slug: string;
-    day: number;
     prologues: Prologue[];
     summary: string;
     paragraphs: string[];
@@ -20,7 +19,6 @@ export interface StoryDTO {
     author: Author;
     title: string;
     slug: string;
-    day: number;
     prologues: any[];
     summary: any[];
     paragraphs: any[];

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -4,6 +4,7 @@ interface StorylistBase {
     title: string;
     slug: string;
     editionPrefix: string;
+    count: number;
     description?: string[];
     language?: string;
     imageUrl?: string;

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -11,8 +11,8 @@ import { DestroyedDirective } from '../../directives/destroyed.directive';
     hostDirectives: [DestroyedDirective],
 })
 export class HomeComponent {
-    latestStories: StoryList | undefined;
-    oldStories: StoryList | undefined;
+    latestStories!: StoryList;
+    oldStories!: StoryList;
 
     constructor() {
         const destroyedDirective = inject(DestroyedDirective);

--- a/src/app/pages/story-list/story-list.component.ts
+++ b/src/app/pages/story-list/story-list.component.ts
@@ -1,7 +1,7 @@
-import { Component, inject, OnDestroy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { StoryService } from '../../providers/story.service';
-import { Subscription, switchMap, takeUntil } from 'rxjs';
+import { switchMap, takeUntil } from 'rxjs';
 import { StoryList } from '../../models/storylist.model';
 import { DestroyedDirective } from '../../directives/destroyed.directive';
 
@@ -12,7 +12,8 @@ import { DestroyedDirective } from '../../directives/destroyed.directive';
     hostDirectives: [DestroyedDirective],
 })
 export class StoryListComponent {
-    storyList: StoryList | undefined;
+    storyList!: StoryList;
+
     constructor() {
         const activatedRoute = inject(ActivatedRoute);
         const destroyedDirective = inject(DestroyedDirective);
@@ -22,7 +23,6 @@ export class StoryListComponent {
             .pipe(
                 // ToDo: Rediseñar signature del método para poder traer todas las historias y luego hacer fetch vía scroll/ver más
                 switchMap(({ slug }) => {
-                    this.storyList = undefined;
                     return storyService.getLatest(slug, 60);
                 }),
                 takeUntil(destroyedDirective.destroyed$)

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -1,6 +1,6 @@
-import { Component, inject, OnDestroy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { combineLatest, Subscription, switchMap, takeUntil } from 'rxjs';
+import { combineLatest, switchMap, takeUntil } from 'rxjs';
 import { StoryService } from '../../providers/story.service';
 import { Story } from '../../models/story.model';
 import { StoryList } from '../../models/storylist.model';
@@ -13,8 +13,8 @@ import { DestroyedDirective } from '../../directives/destroyed.directive';
     hostDirectives: [DestroyedDirective],
 })
 export class StoryComponent {
-    story: Story | undefined;
-    storylist: StoryList | undefined;
+    story!: Story;
+    storylist!: StoryList;
 
     dummyList = Array(10);
 
@@ -26,8 +26,6 @@ export class StoryComponent {
         activatedRoute.queryParams
             .pipe(
                 switchMap(({ slug, list }) => {
-                    this.story = undefined;
-                    this.storylist = undefined;
                     return combineLatest([storyService.getBySlug(slug), storyService.getLatest(list, 10)]);
                 }),
                 takeUntil(destroyedDirective.destroyed$)


### PR DESCRIPTION
# Resumen
* Eliminar campo day de schema Story.
* Eliminar referencias al campo en queries de serverless APIs.
* Adapta `StoryCard` para trabajar con un index en reemplazo del uso de la propiedad `day`.
  * Cálculo de # de edición de cada storylist en base a orden de array. 

## Otros cambios
* Se agrega campo count a modelo Story.
* Se define a los miembros de tipo `Story` y `StoryList` como obligatorios en los componentes de Angular.
* Agrega archivo de migración para ejecutar un `unset` de los documentos Story en CMS.