### PR TITLE
[#177] Implementacion de entidad Publication

### DIFF
--- a/api/story/latest.ts
+++ b/api/story/latest.ts
@@ -10,6 +10,8 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
  */
 export default async function get(req: VercelRequest, res: VercelResponse) {
     const { slug, amount } = req.query;
+    const limit = parseInt(amount as string) - 1;
+
     const query = `*[_type == 'storylist' && slug.current == '${slug}'][0]
                     { 
                         _id,
@@ -37,7 +39,7 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
                                 approximateReadingTime,
                                 'author': author-> { name, image, nationality-> }
                             }
-                        }[0..${amount}]
+                        }[0..${limit}]
                     }`;
 
     const result = await client.fetch(query, {});

--- a/api/story/latest.ts
+++ b/api/story/latest.ts
@@ -60,7 +60,5 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
         })),
     };
 
-    console.log(storylist)
-
     res.json(storylist);
 }

--- a/api/story/latest.ts
+++ b/api/story/latest.ts
@@ -32,7 +32,7 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
                             review,
                             forewords,
                             approximateReadingTime,
-                            'author': author-> { ..., nationality-> }
+                            'author': author-> { name, image, nationality-> }
                         } | [${(-amount)}..-1]
                     }`;
 

--- a/api/story/latest.ts
+++ b/api/story/latest.ts
@@ -19,6 +19,7 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
                         title,
                         description,
                         language,
+                        displayDates,
                         editionPrefix,
                         'count': count(*[ _type == 'publication' && storylist._ref == ^._id ]),
                         'publications': *[ _type == 'publication' && storylist._ref == ^._id ] | order(order desc){

--- a/api/story/latest.ts
+++ b/api/story/latest.ts
@@ -1,7 +1,6 @@
 import { mapAuthor, mapPrologues } from '../_utils/functions';
 import { client } from '../_helpers/sanity-connector';
 import { VercelRequest, VercelResponse } from '@vercel/node';
-import { StoryDAO } from '../_models/story-dao.model';
 
 /**
  * Obtiene las últimas cinco historias almacenadas en Sanity
@@ -19,21 +18,26 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
                         description,
                         language,
                         editionPrefix,
-                        'count': count(stories[]),
-                        'stories': stories[]->{
-                            _id,
-                            'slug': slug.current,
-                            title,
-                            originalLink,
-                            forewords,
-                            categories,
-                            publishedAt,
-                            body[0...2],
-                            review,
-                            forewords,
-                            approximateReadingTime,
-                            'author': author-> { name, image, nationality-> }
-                        } | [${(-amount)}..-1]
+                        'count': count(*[ _type == 'publication' && storylist._ref == ^._id ]),
+                        'publications': *[ _type == 'publication' && storylist._ref == ^._id ] | order(order desc){
+                            order,
+                            publishingDate,
+                            published,
+                            'story': story->{
+                                _id,
+                                'slug': slug.current,
+                                title,
+                                originalLink,
+                                forewords,
+                                categories,
+                                publishedAt,
+                                body[0...2],
+                                review,
+                                forewords,
+                                approximateReadingTime,
+                                'author': author-> { name, image, nationality-> }
+                            }
+                        }[0..${amount}]
                     }`;
 
     const result = await client.fetch(query, {});
@@ -44,15 +48,19 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
 
     const storylist = {
         ...result,
-        stories: result.stories.map((story: StoryDAO) => ({
-            ...story,
-            id: story._id,
-            summary: story.review,
-            paragraphs: story.body,
-            author: mapAuthor(story.author),
-            prologues: mapPrologues(story.forewords),
-        })).reverse(),
+        publications: result.publications.map((publication: any) => ({
+            ...publication,
+            story: {
+                ...publication.story,
+                summary: publication.story.review,
+                paragraphs: publication.story.body,
+                author: mapAuthor(publication.story.author),
+                prologues: mapPrologues(publication.story.forewords),
+            },
+        })),
     };
+
+    console.log(storylist)
 
     res.json(storylist);
 }

--- a/cms/package.json
+++ b/cms/package.json
@@ -18,6 +18,7 @@
     "@sanity/cross-dataset-duplicator": "^1.0.0",
     "@sanity/icons": "^2.2.2",
     "@sanity/vision": "^3.8.1",
+    "dayjs": "^1.11.7",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -4,6 +4,7 @@ specifiers:
   '@sanity/cross-dataset-duplicator': ^1.0.0
   '@sanity/icons': ^2.2.2
   '@sanity/vision': ^3.8.1
+  dayjs: ^1.11.7
   prop-types: ^15.8.1
   react: ^18.2.0
   react-dom: ^18.2.0
@@ -16,6 +17,7 @@ dependencies:
   '@sanity/cross-dataset-duplicator': 1.0.0_in4ddu4pccfjfvcv3vb3fvanua
   '@sanity/icons': 2.2.2_react@18.2.0
   '@sanity/vision': 3.8.1_naxdq4ftv6hnbklxoymdh4kece
+  dayjs: 1.11.7
   prop-types: 15.8.1
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
@@ -2062,6 +2064,10 @@ packages:
 
   /date-now/1.0.1:
     resolution: {integrity: sha512-yiizelQCqYLUEVT4zqYihOW6Ird7Qyc6fD3Pv5xGxk4+Jz0rsB1dMN2KyNV6jgOHYh5K+sPGCSOknQN4Upa3pg==}
+    dev: false
+
+  /dayjs/1.11.7:
+    resolution: {integrity: sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==}
     dev: false
 
   /debounce/1.0.0:

--- a/cms/schemas/publication.ts
+++ b/cms/schemas/publication.ts
@@ -1,0 +1,65 @@
+export default {
+    name: 'publication',
+    title: 'Publicación',
+    type: 'document',
+    preview: {
+        select: {
+            order: 'order',
+            storylist: 'storylist.title',
+            story: 'story.title',
+            published: 'published',
+            publishingDate: 'publishingDate',
+        },
+        prepare(selection) {
+            const { order, storylist, story, published, publishingDate } = selection;
+
+
+
+            return {
+                title: `${story} | ${order}° en ${storylist}`,
+                subtitle: `${
+                    !published ? 'No publicado' : ('Publicado' + (publishingDate ? ' el ' + publishingDate : ''))
+                }`,
+            };
+        },
+    },
+    fields: [
+        {
+            name: 'order',
+            title: 'Orden en lista',
+            description:
+                'Campo que detalla el # de edición, el día de lanzamiento, etc. Se utiliza para determinar cómo ordenar una publicación dentro de una Storylist determinada. Este campo no podrá estar duplicado para historias dentro de una misma Storylist.',
+            type: 'number',
+            validation: (Rule) => Rule.required().min(1),
+        },
+        {
+            name: 'story',
+            title: 'Historia de la publicación',
+            type: 'reference',
+            to: [{ type: 'story' }],
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: 'storylist',
+            title: 'Storylist',
+            description: 'Storylist a la que pertenece la publicación.',
+            type: 'reference',
+            to: [{ type: 'storylist' }],
+            validation: (Rule) => Rule.required(),
+        },
+        {
+            name: 'publishingDate',
+            title: 'Fecha de publicación',
+            type: 'date',
+        },
+        {
+            name: 'published',
+            title: '¿Publicado?',
+            description:
+                'Determina si la publicación fue o no liberada. Si el valor es false, la publicación no se mostrará como parte de la Storylist',
+            type: 'boolean',
+            validation: (Rule) => Rule.required(),
+            initialValue: false,
+        },
+    ],
+};

--- a/cms/schemas/schema.ts
+++ b/cms/schemas/schema.ts
@@ -2,20 +2,21 @@
 // Then import schema types from any plugins that might expose them
 
 // We import object and document schemas
-import blockContent from './blockContent'
-import story from './story'
-import author from './author'
-import country from './country'
-import storyList from "./storylist";
+import blockContent from './blockContent';
+import story from './story';
+import author from './author';
+import country from './country';
+import storyList from './storylist';
+import publication from './publication';
 
 export default [
-  // The following are document types which will appear in the studio.
-  // When added to this list, object types can be used as
-  // { type: 'typename' } in other document schemas
-  story,
-  storyList,
-  author,
-  country,
-  blockContent,
-]
-
+    // The following are document types which will appear in the studio.
+    // When added to this list, object types can be used as
+    // { type: 'typename' } in other document schemas
+    story,
+    publication,
+    storyList,
+    author,
+    country,
+    blockContent,
+];

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -29,6 +29,12 @@ export default {
             type: 'string',
         },
         {
+            name: 'displayDates',
+            title: 'Mostrar fechas',
+            type: 'boolean',
+            initialValue: false,
+        },
+        {
             name: 'editionPrefix',
             title: 'Prefijo de edición',
             description:

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -44,11 +44,5 @@ export default {
                 hotspot: true,
             },
         },
-        {
-            name: 'stories',
-            title: 'Historias',
-            type: 'array',
-            of: [{ type: 'reference', to: { type: 'story' } }],
-        },
     ],
 };

--- a/cms/scripts/copyStoriesToPublications.ts
+++ b/cms/scripts/copyStoriesToPublications.ts
@@ -5,19 +5,20 @@
 import { client } from '../../api/_helpers/sanity-connector';
 import dayjs = require('dayjs');
 
-const fetchStorylists = () => client.fetch(`*[_type == 'storylist' && slug.current == 'verano-2022']`);
+// const fetchStorylists = () => client.fetch(`*[_type == 'storylist' && slug.current == 'verano-2022']`);
+const fetchStorylists = () => client.fetch(`*[_type == 'storylist' && slug.current == 'fec-english-sessions']`);
 
 const buildCommits = (storylist, stories) => {
-
     // console.log(stories);
 
     const date = dayjs('2022-01-01');
+    // const date = dayjs('2022-01-22');
 
     return stories.map((story, index) => {
         return {
             _id: `publication--${storylist._id}--${story._ref}`,
             _type: 'publication',
-            order: index+1,
+            order: index + 1,
             story: { _key: story._key, _ref: story._ref, _type: 'reference' },
             storylist: { _key: storylist._key, _ref: storylist._id, _type: 'reference' },
             // published: true,

--- a/cms/scripts/copyStoriesToPublications.ts
+++ b/cms/scripts/copyStoriesToPublications.ts
@@ -1,0 +1,55 @@
+// RO - 2023-25-03
+// Este script fue utilizado el 25/03/2023 para eliminar el campo day de los documentos de tipo Story en Sanity CMS.
+// Queda aquí a modo de ejemplo para saber cómo proceder a la hora de escribir otro script de migración a futuro.
+
+import { client } from '../../api/_helpers/sanity-connector';
+import dayjs = require('dayjs');
+
+const fetchStorylists = () => client.fetch(`*[_type == 'storylist' && slug.current == 'verano-2022']`);
+
+const buildCommits = (storylist, stories) => {
+
+    // console.log(stories);
+
+    const date = dayjs('2022-01-01');
+
+    return stories.map((story, index) => {
+        return {
+            _id: `publication--${storylist._id}--${story._ref}`,
+            _type: 'publication',
+            order: index+1,
+            story: { _key: story._key, _ref: story._ref, _type: 'reference' },
+            storylist: { _key: storylist._key, _ref: storylist._id, _type: 'reference' },
+            // published: true,
+            published: true,
+            publishingDate: date.add(index, 'days').format('YYYY-MM-DD'),
+            // publishingDate: date.format('YYYY-MM-DD'),
+        };
+    });
+};
+
+const createTransaction = (commits) => commits.reduce((tx, commit) => tx.create(commit), client.transaction());
+
+const commitTransaction = (tx) => tx.commit();
+
+const migrateBatch = async () => {
+    const storylists = await fetchStorylists();
+    let commits = [];
+
+    for (const storylist of storylists) {
+        commits = commits.concat(buildCommits(storylist, storylist.stories));
+        console.log(commits);
+    }
+
+    if (commits.length === 0) {
+        console.log('No hay documentos para migrar!');
+        return null;
+    }
+    const transaction = createTransaction(commits);
+    await commitTransaction(transaction);
+};
+
+migrateBatch().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/app/components/story-card/story-card.component.html
+++ b/src/app/components/story-card/story-card.component.html
@@ -1,39 +1,41 @@
 <article>
-    <ng-container *ngIf="!!story; else skeleton">
-        <header class="card-header">
-            <cuentoneta-story-edition-date-label [label]="editionLabel"></cuentoneta-story-edition-date-label>
-        </header>
-        <section>
-            <h1 class="card-title">{{ story.title }}</h1>
-            <!-- ToDo: Optimizar payload tratado para mostrar el resumen de cada tarjeta (#115)-->
-            <p class="content" [innerHTML]="story.paragraphs[0] + ' ' + story.paragraphs[1]"></p>
-        </section>
-        <label class="reading-time">{{ story.approximateReadingTime }} minutos</label>
-        <hr />
-        <footer class="author-info flex flex-row items-center">
-            <img
-                class="author-image"
-                width="40"
-                height="40"
-                [alt]="'Retrato de ' + story.author.name"
-                [ngSrc]="story.author.imageUrl + '?h=40&w=40'"
-            />
-            <div>
-                <label class="author-name">{{ story.author.name }}</label>
-                <ng-container *ngIf="story.author.nationality as nationality">
-                    <div class="flex items-center">
-                        <img
-                            class="flag"
-                            width="20"
-                            height="15"
-                            [alt]="'Bandera de ' + nationality.country"
-                            [ngSrc]="nationality.flag + '?w=20&h=15'"
-                        />
-                        <label class="country">{{ nationality.country }}</label>
-                    </div>
-                </ng-container>
-            </div>
-        </footer>
+    <ng-container *ngIf="!!publication; else skeleton">
+        <ng-container *ngIf="publication.story as story">
+            <header class="card-header">
+                <cuentoneta-story-edition-date-label [label]="editionLabel"></cuentoneta-story-edition-date-label>
+            </header>
+            <section>
+                <h1 class="card-title">{{ story.title }}</h1>
+                <!-- ToDo: Optimizar payload tratado para mostrar el resumen de cada tarjeta (#115)-->
+                <p class="content" [innerHTML]="story.paragraphs[0] + ' ' + story.paragraphs[1]"></p>
+            </section>
+            <label class="reading-time">{{ story.approximateReadingTime }} minutos</label>
+            <hr/>
+            <footer class="author-info flex flex-row items-center">
+                <img
+                        class="author-image"
+                        width="40"
+                        height="40"
+                        [alt]="'Retrato de ' + story.author.name"
+                        [ngSrc]="story.author.imageUrl + '?h=40&w=40'"
+                />
+                <div>
+                    <label class="author-name">{{ story.author.name }}</label>
+                    <ng-container *ngIf="story.author.nationality as nationality">
+                        <div class="flex items-center">
+                            <img
+                                    class="flag"
+                                    width="20"
+                                    height="15"
+                                    [alt]="'Bandera de ' + nationality.country"
+                                    [ngSrc]="nationality.flag + '?w=20&h=15'"
+                            />
+                            <label class="country">{{ nationality.country }}</label>
+                        </div>
+                    </ng-container>
+                </div>
+            </footer>
+        </ng-container>
     </ng-container>
 </article>
 

--- a/src/app/components/story-card/story-card.component.ts
+++ b/src/app/components/story-card/story-card.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Story } from '../../models/story.model';
+import { Publication } from '../../models/storylist.model';
 
 @Component({
     selector: 'cuentoneta-story-card',
@@ -10,15 +11,15 @@ export class StoryCardComponent implements OnInit {
     @Input() editionPrefix: string | undefined;
     @Input() editionSuffix: string | undefined;
     @Input() displayDate: boolean = false;
-    @Input() story: Story | undefined;
+    @Input() publication: Publication<Story> | undefined;
     @Input() editionIndex: number = 0;
 
     editionLabel: string = '';
 
     ngOnInit() {
-        this.editionLabel = this.editionPrefix + ' ' + this.editionIndex + ' - ' + this.story?.publishedAt;
+        this.editionLabel = this.editionPrefix + ' ' + this.editionIndex + ' - ' + this.publication?.publishingDate;
         this.editionLabel = `${this.editionPrefix} ${this.editionIndex} ${
-            this.displayDate ? ' - ' + this.story?.publishedAt : ''
+            this.displayDate ? ' - ' + this.publication?.publishingDate : ''
         }${this.editionSuffix ? ' | ' + this.editionSuffix : ''}`;
     }
 }

--- a/src/app/components/story-list-card-deck/story-list-card-deck.component.html
+++ b/src/app/components/story-list-card-deck/story-list-card-deck.component.html
@@ -22,12 +22,12 @@
 
 <ng-template #storylistTemplate>
     <ng-container *ngIf="!!storylist">
-        <ng-container *ngFor="let story of storylist.stories; let editionIndex = index">
-            <a [routerLink]="['/story']" [queryParams]="{ slug: story?.slug, list: storylist.slug }">
+        <ng-container *ngFor="let publication of storylist.publications; let editionIndex = index">
+            <a [routerLink]="['/story']" [queryParams]="{ slug: publication.story.slug, list: storylist.slug }">
                 <cuentoneta-story-card
                     [displayDate]="displayDates"
                     [editionPrefix]="storylist.editionPrefix"
-                    [story]="story"
+                    [publication]="publication"
                     [editionIndex]="storylist.count - editionIndex"
                 ></cuentoneta-story-card>
             </a>

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.html
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.html
@@ -6,22 +6,22 @@
     </header>
 
     <ng-container *ngIf="!!storyList; else bodySkeleton">
-        <ng-container *ngFor="let story of storyList.stories; let editionIndex = index">
-            <a [routerLink]="['/story']" [queryParams]="{ slug: story.slug, list: storyList.slug }">
+        <ng-container *ngFor="let publication of storyList.publications; let editionIndex = index">
+            <a [routerLink]="['/story']" [queryParams]="{ slug: publication.story.slug, list: storyList.slug }">
                 <article>
                     <cuentoneta-story-edition-date-label
                         class="edition-and-label"
-                        [label]="getEditionLabel(story, storyList.count - editionIndex)"
+                        [label]="getEditionLabel(publication, storyList.count - editionIndex)"
                     ></cuentoneta-story-edition-date-label>
-                    <h4 class="title">{{ story.title }}</h4>
-                    <h5 class="author">{{ story.author.name }}</h5>
+                    <h4 class="title">{{ publication.story.title }}</h4>
+                    <h5 class="author">{{ publication.story.author.name }}</h5>
                 </article>
             </a>
         </ng-container>
     </ng-container>
 
     <!--    ToDo: Implementar navegación para visualizar lista completa-->
-    <footer *ngIf="storyList && storyList.stories.length > 10">
+    <footer *ngIf="storyList && storyList.publications.length > 10">
         <h3 class="story-list-title">Ver más...</h3>
     </footer>
 </section>

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { StoryList } from '../../models/storylist.model';
+import { Publication, StoryList } from '../../models/storylist.model';
 import { Story } from '../../models/story.model';
 
 @Component({
@@ -13,7 +13,9 @@ export class StoryNavigationBarComponent {
     dummyList: null[] = Array(10);
 
     // ToDo: Separar card de cada cuento de la lista en su propio componente, para evitar usar un método en el template
-    getEditionLabel(story: Story, editionIndex: number = 0): string {
-        return `${this.storyList?.editionPrefix} ${editionIndex} - ${story.publishedAt}`;
+    getEditionLabel(publication: Publication<Story>, editionIndex: number = 0): string {
+        return `${this.storyList?.editionPrefix} ${editionIndex} ${
+            publication.publishingDate ? ' - ' + publication.publishingDate : ''
+        }`;
     }
 }

--- a/src/app/models/author.model.ts
+++ b/src/app/models/author.model.ts
@@ -3,7 +3,7 @@ export interface Author {
     name: string;
     imageUrl: string;
     nationality: AuthorNationality;
-    biography: string;
+    biography?: string;
     fullBioUrl: string;
 }
 

--- a/src/app/models/content.model.ts
+++ b/src/app/models/content.model.ts
@@ -9,7 +9,6 @@ export interface StorylistDeckConfig {
     slug: string;
     highlightFirstRow: boolean;
     amount: number;
-    displayDates: boolean;
 }
 
 export interface StorylistCardDeck extends StorylistDeckConfig {

--- a/src/app/models/content.model.ts
+++ b/src/app/models/content.model.ts
@@ -9,6 +9,7 @@ export interface StorylistDeckConfig {
     slug: string;
     highlightFirstRow: boolean;
     amount: number;
+    displayDates: boolean;
 }
 
 export interface StorylistCardDeck extends StorylistDeckConfig {

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -1,27 +1,23 @@
 import { Author } from './author.model';
 import { Prologue } from './prologue.model';
 
-export interface Story {
+export interface StoryBase {
     id: number;
-    author: Author;
     title: string;
     slug: string;
+    approximateReadingTime: number;
+    author: Author;
+}
+
+export interface Story extends StoryBase {
     prologues: Prologue[];
     summary: string;
     paragraphs: string[];
-    publishedAt: string;
-    approximateReadingTime: number;
 }
 
 // ToDo: Agregar tipo BlockContent para tratar datos de texto que vienen desde Sanity (#114)
-export interface StoryDTO {
-    id: number;
-    author: Author;
-    title: string;
-    slug: string;
+export interface StoryDTO extends StoryBase {
     prologues: any[];
     summary: any[];
     paragraphs: any[];
-    publishedAt: string;
-    approximateReadingTime: number;
 }

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -21,3 +21,7 @@ export interface StoryDTO extends StoryBase {
     summary: any[];
     paragraphs: any[];
 }
+
+export interface StoryCard extends Story {
+    author: Omit<Author, 'biography'>;
+}

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -1,4 +1,4 @@
-import { Story, StoryDTO } from './story.model';
+import { Story, StoryBase, StoryDTO } from './story.model';
 
 interface StorylistBase {
     title: string;
@@ -10,8 +10,15 @@ interface StorylistBase {
     imageUrl?: string;
 }
 export interface StoryList extends StorylistBase {
-    stories: Story[];
+    publications: Publication<Story>[];
 }
 export interface StoryListDTO extends StorylistBase {
-    stories: StoryDTO[];
+    publications: Publication<StoryDTO>[];
+}
+
+export interface Publication<T extends StoryBase> {
+    order: number;
+    published: boolean;
+    publishingDate?: string;
+    story: T;
 }

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -3,6 +3,7 @@ import { Story, StoryBase, StoryDTO } from './story.model';
 interface StorylistBase {
     title: string;
     slug: string;
+    displayDates: boolean;
     editionPrefix: string;
     count: number;
     description?: string[];

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -25,6 +25,7 @@
                     [highlightFirstRow]="storylistDeck.highlightFirstRow"
                     [displayTitle]="true"
                     [number]="storylistDeck.amount"
+                    [displayDates]="storylistDeck.displayDates"
                 ></cuentoneta-story-list-card-deck>
             </ng-container>
         </ng-container>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -25,7 +25,7 @@
                     [highlightFirstRow]="storylistDeck.highlightFirstRow"
                     [displayTitle]="true"
                     [number]="storylistDeck.amount"
-                    [displayDates]="storylistDeck.displayDates"
+                    [displayDates]="storylistDeck.storylist?.displayDates ?? false"
                 ></cuentoneta-story-list-card-deck>
             </ng-container>
         </ng-container>

--- a/src/app/pages/story-list/story-list.component.html
+++ b/src/app/pages/story-list/story-list.component.html
@@ -1,3 +1,3 @@
 <main>
-    <cuentoneta-story-list-card-deck [storylist]="storyList"></cuentoneta-story-list-card-deck>
+    <cuentoneta-story-list-card-deck [storylist]="storyList" [displayDates]="storyList.displayDates"></cuentoneta-story-list-card-deck>
 </main>


### PR DESCRIPTION
# Resumen
Se agrega el modelo `Publication`, lo cual transforma al modelo `Story` en independiente de la fecha y otros detalles de cuándo se publica la historia y en qué lista. Además, se invierte la dependencia que las `Storylist` tenían sobre `Story`, haciendo ahora que los objetos de tipo `Publication` tengan una relación tanto con una `Story` como con una `Storylist`, permitiendo que atributos relevantes a una publicación de un cuento en un momento y lista dadas sea independiente de los modelos preexistentes.

Se ha migrado la información del gestor de contenido para soportar el nuevo modelo, como así también el endpoint `/latest`, más las vistas y componentes de frontend correspondientes.

## Otros cambios
* Visualización de fechas en base al campo `displayDates`, ahora incluido en el modelo `Storylist`.
* Optimización de query `getLatest`: se ignora ahora el bio del autor para la obtención de información de las storylist cards.