### PR TITLE
[#179 - FE] - Ajusta altura de barra vertical en prólogos

### DIFF
--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -12,10 +12,10 @@
         </header>
 
         <ng-container *ngIf="!!story && !fetchContentDirective.isLoading">
-            <section class="prologues" *ngIf="!!story.prologues && story.prologues.length > 0">
+            <section class="prologues flex" *ngIf="!!story.prologues && story.prologues.length > 0">
                 <ng-container *ngFor="let prologue of story.prologues">
+                    <div class="bar"></div>
                     <p class="prologue flex items-center">
-                        <span></span>
                         {{ prologue.text }}&nbsp;<em *ngIf="prologue.reference">{{ prologue.reference }}</em>
                     </p>
                 </ng-container>

--- a/src/app/pages/story/story.component.scss
+++ b/src/app/pages/story/story.component.scss
@@ -57,10 +57,9 @@ article {
 
     .prologues {
         margin-bottom: $spacing-10;
-        span {
+        .bar {
             border-left: 3px solid $primary-500;
             margin-right: $spacing-4;
-            height: $spacing-5;
         }
         .prologue {
             @include source-serif-pro-body-lg;


### PR DESCRIPTION
# Resumen
Ajusta altura de barra vertical a la izquierda de los prólogos, según altura del párrafo.

## Screenshot
![image](https://user-images.githubusercontent.com/32349705/232339467-881c139d-248b-4983-aaf0-0011ef748efb.png)
