### PR TITLE
[FE-#196] Actualizar metadata en navegaciones

### DIFF
--- a/src/app/directives/meta-tags.directive.spec.ts
+++ b/src/app/directives/meta-tags.directive.spec.ts
@@ -1,0 +1,8 @@
+import { MetaTagsDirective } from './meta-tags.directive';
+
+describe('MetaTagsDirective', () => {
+  it('should create an instance', () => {
+    const directive = new MetaTagsDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/directives/meta-tags.directive.ts
+++ b/src/app/directives/meta-tags.directive.ts
@@ -1,0 +1,35 @@
+import { Directive, inject } from '@angular/core';
+import { Meta, Title } from '@angular/platform-browser';
+
+@Directive({
+  selector: '[cuentonetaMetaTags]',
+  standalone: true,
+})
+export class MetaTagsDirective {
+  private metaTagService = inject(Meta);
+  private titleService = inject(Title);
+
+  setTitle(title: string) {
+    this.titleService.setTitle(title);
+    this.metaTagService.updateTag({
+      name: 'twitter:title',
+      content: title,
+    });
+
+    this.metaTagService.updateTag({
+      property: 'og:title',
+      content: title,
+    });
+  }
+
+  setDescription(content: string) {
+    this.metaTagService.updateTag({
+      name: 'twitter:description',
+      content: content,
+    });
+    this.metaTagService.updateTag({
+      property: 'og:description',
+      content: content,
+    });
+  }
+}

--- a/src/app/pages/story-list/story-list.component.ts
+++ b/src/app/pages/story-list/story-list.component.ts
@@ -1,7 +1,8 @@
 // Core
 import { Component, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { pipe, switchMap, takeUntil } from 'rxjs';
+import { switchMap, takeUntil } from 'rxjs';
+import { Meta, Title } from '@angular/platform-browser';
 
 // Models
 import { StoryList } from '../../models/storylist.model';
@@ -27,6 +28,8 @@ export class StoryListComponent {
         const activatedRoute = inject(ActivatedRoute);
         const destroyedDirective = inject(DestroyedDirective);
         const storyService = inject(StoryService);
+        const metaTagService = inject(Meta);
+        const titleService = inject(Title);
 
         this.fetchContentDirective
             .fetchContentWithSourceParams$(
@@ -36,8 +39,27 @@ export class StoryListComponent {
                 })
             )
             .pipe(takeUntil(destroyedDirective.destroyed$))
-            .subscribe((storyList) => {
-                this.storyList = storyList;
+            .subscribe((storylist) => {
+                this.storyList = storylist;
+                titleService.setTitle(
+                    `${storylist.title} - La Cuentoneta`
+                );
+                metaTagService.updateTag({
+                    name: 'twitter:title',
+                    content: `"${storylist.title} en La Cuentoneta"`,
+                });
+                metaTagService.updateTag({
+                    name: 'twitter:description',
+                    content: `Colección "${storylist.title}", una storylist en La Cuentoneta`,
+                });
+                metaTagService.updateTag({
+                    property: 'og:title',
+                    content: `"${storylist.title} en La Cuentoneta"`,
+                });
+                metaTagService.updateTag({
+                    property: 'og:description',
+                    content: `Colección "${storylist.title}", una storylist en La Cuentoneta`,
+                });
             });
     }
 }

--- a/src/app/pages/story-list/story-list.component.ts
+++ b/src/app/pages/story-list/story-list.component.ts
@@ -2,7 +2,6 @@
 import { Component, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { switchMap, takeUntil } from 'rxjs';
-import { Meta, Title } from '@angular/platform-browser';
 
 // Models
 import { StoryList } from '../../models/storylist.model';
@@ -13,53 +12,43 @@ import { StoryService } from '../../providers/story.service';
 // Directives
 import { DestroyedDirective } from '../../directives/destroyed.directive';
 import { FetchContentDirective } from '../../directives/fetch-content.directive';
+import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 
 @Component({
-    selector: 'cuentoneta-story-list',
-    templateUrl: './story-list.component.html',
-    styleUrls: ['./story-list.component.scss'],
-    hostDirectives: [DestroyedDirective, FetchContentDirective],
+  selector: 'cuentoneta-story-list',
+  templateUrl: './story-list.component.html',
+  styleUrls: ['./story-list.component.scss'],
+  hostDirectives: [
+    DestroyedDirective,
+    FetchContentDirective,
+    MetaTagsDirective,
+  ],
 })
 export class StoryListComponent {
-    fetchContentDirective = inject(FetchContentDirective<StoryList>);
-    storyList!: StoryList | undefined;
+  fetchContentDirective = inject(FetchContentDirective<StoryList>);
+  storyList!: StoryList | undefined;
 
-    constructor() {
-        const activatedRoute = inject(ActivatedRoute);
-        const destroyedDirective = inject(DestroyedDirective);
-        const storyService = inject(StoryService);
-        const metaTagService = inject(Meta);
-        const titleService = inject(Title);
+  constructor() {
+    const activatedRoute = inject(ActivatedRoute);
+    const destroyedDirective = inject(DestroyedDirective);
+    const metaTagsDirective = inject(MetaTagsDirective);
 
-        this.fetchContentDirective
-            .fetchContentWithSourceParams$(
-                activatedRoute.queryParams,
-                switchMap(({ slug }) => {
-                    return storyService.getLatest(slug, 60);
-                })
-            )
-            .pipe(takeUntil(destroyedDirective.destroyed$))
-            .subscribe((storylist) => {
-                this.storyList = storylist;
-                titleService.setTitle(
-                    `${storylist.title} - La Cuentoneta`
-                );
-                metaTagService.updateTag({
-                    name: 'twitter:title',
-                    content: `"${storylist.title} en La Cuentoneta"`,
-                });
-                metaTagService.updateTag({
-                    name: 'twitter:description',
-                    content: `Colección "${storylist.title}", una storylist en La Cuentoneta`,
-                });
-                metaTagService.updateTag({
-                    property: 'og:title',
-                    content: `"${storylist.title} en La Cuentoneta"`,
-                });
-                metaTagService.updateTag({
-                    property: 'og:description',
-                    content: `Colección "${storylist.title}", una storylist en La Cuentoneta`,
-                });
-            });
-    }
+    const storyService = inject(StoryService);
+
+    this.fetchContentDirective
+      .fetchContentWithSourceParams$(
+        activatedRoute.queryParams,
+        switchMap(({ slug }) => {
+          return storyService.getLatest(slug, 60);
+        })
+      )
+      .pipe(takeUntil(destroyedDirective.destroyed$))
+      .subscribe((storylist) => {
+        this.storyList = storylist;
+        metaTagsDirective.setTitle(`${storylist.title} en La Cuentoneta`);
+        metaTagsDirective.setDescription(
+          `Colección "${storylist.title}", una storylist en La Cuentoneta`
+        );
+      });
+  }
 }

--- a/src/app/pages/story-list/story-list.component.ts
+++ b/src/app/pages/story-list/story-list.component.ts
@@ -45,9 +45,9 @@ export class StoryListComponent {
       .pipe(takeUntil(destroyedDirective.destroyed$))
       .subscribe((storylist) => {
         this.storyList = storylist;
-        metaTagsDirective.setTitle(`${storylist.title} en La Cuentoneta`);
+        metaTagsDirective.setTitle(`"${storylist.title}" en La Cuentoneta`);
         metaTagsDirective.setDescription(
-          `Colección "${storylist.title}", una storylist en La Cuentoneta`
+          `Colección "${storylist.title}", una storylist en La Cuentoneta: Una iniciativa que busca fomentar y hacer accesible la lectura digital.`
         );
       });
   }

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -2,6 +2,7 @@
 import { Component, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { combineLatest, switchMap, takeUntil } from 'rxjs';
+import { Meta, Title } from '@angular/platform-browser';
 
 // Models
 import { Story } from '../../models/story.model';
@@ -15,35 +16,59 @@ import { DestroyedDirective } from '../../directives/destroyed.directive';
 import { FetchContentDirective } from '../../directives/fetch-content.directive';
 
 @Component({
-    selector: 'cuentoneta-story',
-    templateUrl: './story.component.html',
-    styleUrls: ['./story.component.scss'],
-    hostDirectives: [DestroyedDirective, FetchContentDirective],
+  selector: 'cuentoneta-story',
+  templateUrl: './story.component.html',
+  styleUrls: ['./story.component.scss'],
+  hostDirectives: [DestroyedDirective, FetchContentDirective],
 })
 export class StoryComponent {
-    fetchContentDirective = inject(FetchContentDirective<[Story, StoryList]>);
+  fetchContentDirective = inject(FetchContentDirective<[Story, StoryList]>);
 
-    story!: Story;
-    storylist!: StoryList;
+  story!: Story;
+  storylist!: StoryList;
 
-    dummyList = Array(10);
+  dummyList = Array(10);
 
-    constructor() {
-        const activatedRoute = inject(ActivatedRoute);
-        const destroyedDirective = inject(DestroyedDirective);
-        const storyService = inject(StoryService);
+  constructor() {
+    const activatedRoute = inject(ActivatedRoute);
+    const destroyedDirective = inject(DestroyedDirective);
+    const storyService = inject(StoryService);
+    const metaTagService = inject(Meta);
+    const titleService = inject(Title);
 
-        this.fetchContentDirective
-            .fetchContentWithSourceParams$(
-                activatedRoute.queryParams,
-                switchMap(({ slug, list }) =>
-                    combineLatest([storyService.getBySlug(slug), storyService.getLatest(list, 10)])
-                )
-            )
-            .pipe(takeUntil(destroyedDirective.destroyed$))
-            .subscribe(([story, storylist]) => {
-                this.story = story;
-                this.storylist = storylist;
-            });
-    }
+    this.fetchContentDirective
+      .fetchContentWithSourceParams$(
+        activatedRoute.queryParams,
+        switchMap(({ slug, list }) =>
+          combineLatest([
+            storyService.getBySlug(slug),
+            storyService.getLatest(list, 10),
+          ])
+        )
+      )
+      .pipe(takeUntil(destroyedDirective.destroyed$))
+      .subscribe(([story, storylist]) => {
+        this.story = story;
+        this.storylist = storylist;
+        titleService.setTitle(
+          `${story.title}, de ${story.author.name} - La Cuentoneta`
+        );
+        metaTagService.updateTag({
+          name: 'twitter:title',
+          content: `"${story.title}", de ${story.author.name} - La Cuentoneta`,
+        });
+        metaTagService.updateTag({
+          name: 'twitter:description',
+          content: `"${story.title}", de ${story.author.name}. Parte de la colección "${storylist.title}" en La Cuentoneta`,
+        });
+        metaTagService.updateTag({
+          property: 'og:title',
+          content: `"${story.title}", de ${story.author.name} - La Cuentoneta`,
+        });
+        metaTagService.updateTag({
+          property: 'og:description',
+          content: `"${story.title}", de ${story.author.name}. parte de la colección "${storylist.title}" en La Cuentoneta`,
+        });
+      });
+  }
 }

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -2,7 +2,6 @@
 import { Component, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { combineLatest, switchMap, takeUntil } from 'rxjs';
-import { Meta, Title } from '@angular/platform-browser';
 
 // Models
 import { Story } from '../../models/story.model';
@@ -14,12 +13,17 @@ import { StoryService } from '../../providers/story.service';
 // Directives
 import { DestroyedDirective } from '../../directives/destroyed.directive';
 import { FetchContentDirective } from '../../directives/fetch-content.directive';
+import { MetaTagsDirective } from '../../directives/meta-tags.directive';
 
 @Component({
   selector: 'cuentoneta-story',
   templateUrl: './story.component.html',
   styleUrls: ['./story.component.scss'],
-  hostDirectives: [DestroyedDirective, FetchContentDirective],
+  hostDirectives: [
+    DestroyedDirective,
+    FetchContentDirective,
+    MetaTagsDirective,
+  ],
 })
 export class StoryComponent {
   fetchContentDirective = inject(FetchContentDirective<[Story, StoryList]>);
@@ -32,9 +36,8 @@ export class StoryComponent {
   constructor() {
     const activatedRoute = inject(ActivatedRoute);
     const destroyedDirective = inject(DestroyedDirective);
+    const metaTagsDirective = inject(MetaTagsDirective);
     const storyService = inject(StoryService);
-    const metaTagService = inject(Meta);
-    const titleService = inject(Title);
 
     this.fetchContentDirective
       .fetchContentWithSourceParams$(
@@ -50,25 +53,12 @@ export class StoryComponent {
       .subscribe(([story, storylist]) => {
         this.story = story;
         this.storylist = storylist;
-        titleService.setTitle(
+        metaTagsDirective.setTitle(
           `${story.title}, de ${story.author.name} - La Cuentoneta`
         );
-        metaTagService.updateTag({
-          name: 'twitter:title',
-          content: `"${story.title}", de ${story.author.name} - La Cuentoneta`,
-        });
-        metaTagService.updateTag({
-          name: 'twitter:description',
-          content: `"${story.title}", de ${story.author.name}. Parte de la colección "${storylist.title}" en La Cuentoneta`,
-        });
-        metaTagService.updateTag({
-          property: 'og:title',
-          content: `"${story.title}", de ${story.author.name} - La Cuentoneta`,
-        });
-        metaTagService.updateTag({
-          property: 'og:description',
-          content: `"${story.title}", de ${story.author.name}. Parte de la colección "${storylist.title}" en La Cuentoneta`,
-        });
+        metaTagsDirective.setDescription(
+          `"${story.title}", de ${story.author.name}. Parte de la colección "${storylist.title}" en La Cuentoneta`
+        );
       });
   }
 }

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -67,7 +67,7 @@ export class StoryComponent {
         });
         metaTagService.updateTag({
           property: 'og:description',
-          content: `"${story.title}", de ${story.author.name}. parte de la colección "${storylist.title}" en La Cuentoneta`,
+          content: `"${story.title}", de ${story.author.name}. Parte de la colección "${storylist.title}" en La Cuentoneta`,
         });
       });
   }

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -54,10 +54,10 @@ export class StoryComponent {
         this.story = story;
         this.storylist = storylist;
         metaTagsDirective.setTitle(
-          `${story.title}, de ${story.author.name} - La Cuentoneta`
+          `${story.title}, de ${story.author.name} en La Cuentoneta`
         );
         metaTagsDirective.setDescription(
-          `"${story.title}", de ${story.author.name}. Parte de la colección "${storylist.title}" en La Cuentoneta`
+          `"${story.title}", de ${story.author.name}. Parte de la colección "${storylist.title}" en La Cuentoneta: Una iniciativa que busca fomentar y hacer accesible la lectura digital.`
         );
       });
   }


### PR DESCRIPTION
# Resumen
Se agregó la directiva `MetaTagsDirective` para actualizar la información de OpenGraph y metadata de SEO según la navegación a vista de Storylist y Story.