### PR TITLE
[#248] Agregar parámetro ordering para fetch de `/latest`

### DIFF
--- a/api/story/latest.ts
+++ b/api/story/latest.ts
@@ -9,7 +9,7 @@ import { VercelRequest, VercelResponse } from '@vercel/node';
  * @returns {Promise<null>}
  */
 export default async function get(req: VercelRequest, res: VercelResponse) {
-  const { slug, amount } = req.query;
+  const { slug, amount, ordering = 'asc' } = req.query;
   const limit = parseInt(amount as string) - 1;
 
   const query = `*[_type == 'storylist' && slug.current == '${slug}'][0]
@@ -23,7 +23,7 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
                         editionPrefix,
                         comingNextLabel,
                         'count': count(*[ _type == 'publication' && storylist._ref == ^._id ]),
-                        'publications': *[ _type == 'publication' && storylist._ref == ^._id ] | order(order desc){
+                        'publications': *[ _type == 'publication' && storylist._ref == ^._id ] | order(order ${ordering}){
                             order,
                             publishingDate,
                             published,

--- a/src/app/components/story-list-card-deck/story-list-card-deck.component.html
+++ b/src/app/components/story-list-card-deck/story-list-card-deck.component.html
@@ -27,12 +27,7 @@
 
 <ng-template #storylistTemplate>
   <ng-container *ngIf="!!storylist">
-    <ng-container
-      *ngFor="
-        let publication of storylist.publications;
-        let editionIndex = index
-      "
-    >
+    <ng-container *ngFor="let publication of storylist.publications">
       <a
         [class.disabled]="!publication || !publication.published"
         [routerLink]="
@@ -46,7 +41,7 @@
           [displayDate]="storylist.displayDates"
           [editionPrefix]="storylist.editionPrefix"
           [publication]="publication"
-          [editionIndex]="storylist.count - editionIndex"
+          [editionIndex]="publication.order"
           [comingNextLabel]="storylist.comingNextLabel"
         ></cuentoneta-story-card>
       </a>

--- a/src/app/providers/story.service.ts
+++ b/src/app/providers/story.service.ts
@@ -35,8 +35,15 @@ export class StoryService {
     return this.http.get<Story[]>(`${this.prefix}/original-links`);
   }
 
-  public getLatest(slug: string, amount: number = 5): Observable<StoryList> {
-    const params = new HttpParams().set('slug', slug).set('amount', amount);
+  public getLatest(
+    slug: string,
+    amount: number = 5,
+    ordering: 'asc' | 'desc' = 'asc'
+  ): Observable<StoryList> {
+    const params = new HttpParams()
+      .set('slug', slug)
+      .set('amount', amount)
+      .set('ordering', ordering);
     return this.http
       .get<StoryListDTO>(`${this.prefix}/latest`, { params })
       .pipe(


### PR DESCRIPTION
# Resumen
* Agregado parámetro `ordering` en método `getLatest` y en el endpoint `/latest` correspondiente.

## Otros cambios
* Agregada indexación en base a la propiedad `order` de las publicaciones en `StoryListCardDeckComponent`.