### PR TITLE
[#250] - Agregar soporte para imágenes asociadas a storylists

### DIFF
--- a/api/story/latest.ts
+++ b/api/story/latest.ts
@@ -1,9 +1,12 @@
-import { mapAuthor, mapPrologues } from '../_utils/functions';
+import { mapAuthor, mapPrologues, urlFor } from '../_utils/functions';
 import { client } from '../_helpers/sanity-connector';
 import { VercelRequest, VercelResponse } from '@vercel/node';
 
 /**
- * Obtiene las últimas cinco historias almacenadas en Sanity
+ * Obtiene las N historias correspondientes a una Storylist, según el orden pasado como parámetro.
+ * slug -> Slug de la storylist
+ * amount -> Cantidad de historias retornadas en la propiedad publications
+ * ordering -> Orden en el que se retornarán las stories dentro de la propiedad publications. Default: orden ascendente.
  * @param req
  * @param res
  * @returns {Promise<null>}
@@ -22,6 +25,8 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
                         displayDates,
                         editionPrefix,
                         comingNextLabel,
+                        featuredImage,
+                        images,
                         'count': count(*[ _type == 'publication' && storylist._ref == ^._id ]),
                         'publications': *[ _type == 'publication' && storylist._ref == ^._id ] | order(order ${ordering}){
                             order,
@@ -51,6 +56,15 @@ export default async function get(req: VercelRequest, res: VercelResponse) {
 
   const storylist = {
     ...result,
+    featuredImage: !result.featuredImage
+      ? undefined
+      : urlFor(result.featuredImage).url(),
+    images: !result.images
+      ? []
+      : result.images.map((image) => ({
+          slug: image.slug.current,
+          url: urlFor(image.source).url(),
+        })),
     publications: result.publications.map((publication: any) => {
       const { review, body, forewords, author, ...story } = publication.story;
       return {

--- a/cms/schemas/storylist.ts
+++ b/cms/schemas/storylist.ts
@@ -1,65 +1,109 @@
 export default {
-    name: 'storylist',
-    title: 'Storylists',
-    type: 'document',
-    fields: [
+  name: 'storylist',
+  title: 'Storylists',
+  type: 'document',
+  fields: [
+    {
+      name: 'title',
+      title: 'Título',
+      type: 'string',
+    },
+    {
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'description',
+      title: 'Descripción',
+      type: 'text',
+    },
+    {
+      name: 'language',
+      title: 'Idioma',
+      type: 'string',
+      validation: (Rule) => Rule.required()
+    },
+    {
+      name: 'displayDates',
+      title: 'Mostrar fechas',
+      type: 'boolean',
+      initialValue: false,
+    },
+    {
+      name: 'comingNextLabel',
+      title: 'Etiqueta de "Próximo"',
+      description:
+        'Etiqueta que se mostrará en una publicación programada dentro de una storylist pero que aún no ha sido publicada.',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'editionPrefix',
+      title: 'Prefijo de edición',
+      description:
+        'Prefijo usado para identificar qué representa cada historia en una Storylist (día, edición, historia, etc.)',
+      type: 'string',
+      default: 'Edición',
+    },
+    {
+      name: 'featuredImage',
+      title: 'Imagen destacada',
+      type: 'image',
+      options: {
+        hotspot: true,
+      }
+    },
+    {
+      name: 'images',
+      title: 'Imágenes',
+      description:
+        'Lista de imágenes que se mostrarán en el grid de la storylist.',
+      type: 'array',
+      of: [
         {
-            name: 'title',
-            title: 'Título',
-            type: 'string',
-        },
-        {
-            name: 'slug',
-            title: 'Slug',
-            type: 'slug',
-            options: {
+          name: 'imageObject',
+          title: 'Imagen',
+          type: 'object',
+          fields: [
+            {
+              name: 'source',
+              title: 'Imagen de grid',
+              type: 'image',
+              options: {
+                hotspot: true,
+              },
+            },
+            {
+              name: 'slug',
+              title: 'Slug',
+              type: 'slug',
+              options: {
                 source: 'title',
                 maxLength: 96,
+              },
             },
-            validation: (Rule) => Rule.required(),
-        },
-        {
-            name: 'description',
-            title: 'Descripción',
-            type: 'text',
-        },
-        {
-            name: 'language',
-            title: 'Idioma',
-            type: 'string',
-        },
-        {
-            name: 'displayDates',
-            title: 'Mostrar fechas',
-            type: 'boolean',
-            initialValue: false,
-        },
-        {
-            name: 'comingNextLabel',
-            title: 'Etiqueta de "Próximo"',
-            description:
-                'Etiqueta que se mostrará en una publicación programada dentro de una storylist pero que aún no ha sido publicada.',
-            type: 'string',
-            validation: (Rule) => Rule.required(),
-        },
-        {
-            name: 'editionPrefix',
-            title: 'Prefijo de edición',
-            description:
-                'Prefijo usado para identificar qué representa cada historia en una Storylist (día, edición, historia, etc.)',
-            type: 'string',
-            default: 'Edición',
-        },
-        {
-            name: 'image',
-            title: 'Imagen',
-            type: 'image',
-            options: {
-                hotspot: true,
+          ],
+          preview: {
+            select: {
+              slug: 'slug',
+              source: 'source',
             },
+            prepare({ slug, source }) {
+              return { title: slug.current, media: source };
+            },
+          },
         },
-    ],
-    initialValue: {
-        comingNextLabel: 'Próximamente'
-    }
+      ],
+    },
+  ],
+  initialValue: {
+    comingNextLabel: 'Próximamente',
+    language: 'Español',
+  },
 };

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -1,4 +1,5 @@
 import { Story, StoryBase, StoryDTO } from './story.model';
+import { SanityImageSource } from '@sanity/image-url/lib/types/types';
 
 interface StorylistBase {
     title: string;
@@ -9,7 +10,8 @@ interface StorylistBase {
     comingNextLabel: string;
     description?: string[];
     language?: string;
-    imageUrl?: string;
+    featuredImage?: SanityImageSource;
+    images?: StorylistImage[]
 }
 export interface StoryList extends StorylistBase {
     publications: Publication<Story>[];
@@ -23,4 +25,9 @@ export interface Publication<T extends StoryBase> {
     published: boolean;
     publishingDate?: string;
     story: T;
+}
+
+export interface StorylistImage {
+    slug: string;
+    url: SanityImageSource;
 }

--- a/src/app/models/storylist.model.ts
+++ b/src/app/models/storylist.model.ts
@@ -2,32 +2,30 @@ import { Story, StoryBase, StoryDTO } from './story.model';
 import { SanityImageSource } from '@sanity/image-url/lib/types/types';
 
 interface StorylistBase {
-    title: string;
+  title: string;
+  slug: string;
+  displayDates: boolean;
+  editionPrefix: string;
+  count: number;
+  comingNextLabel: string;
+  description?: string[];
+  language?: string;
+  featuredImage?: SanityImageSource;
+  images?: {
     slug: string;
-    displayDates: boolean;
-    editionPrefix: string;
-    count: number;
-    comingNextLabel: string;
-    description?: string[];
-    language?: string;
-    featuredImage?: SanityImageSource;
-    images?: StorylistImage[]
+    url: SanityImageSource;
+  }[];
 }
 export interface StoryList extends StorylistBase {
-    publications: Publication<Story>[];
+  publications: Publication<Story>[];
 }
 export interface StoryListDTO extends StorylistBase {
-    publications: Publication<StoryDTO>[];
+  publications: Publication<StoryDTO>[];
 }
 
 export interface Publication<T extends StoryBase> {
-    order: number;
-    published: boolean;
-    publishingDate?: string;
-    story: T;
-}
-
-export interface StorylistImage {
-    slug: string;
-    url: SanityImageSource;
+  order: number;
+  published: boolean;
+  publishingDate?: string;
+  story: T;
 }


### PR DESCRIPTION
# Resumen

* Agrega propiedades `featuredImage` e `images` en modelo y schema de Storylist,
* Retorna propiedades `featuredImage` e `images` al fetch de Storylist