### PR TITLE
[#113] - Agregado soporte para configuración de layouts de skeletons

### DIFF
--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -13,6 +13,10 @@
 // Importar cliente de Sanity
 import { client } from '../api/_helpers/sanity-connector';
 
+// Interfaces
+import { StorylistDeckConfig } from '../src/app/models/content.model';
+
+// NodeJS & env
 import { writeFile, existsSync, mkdirSync } from 'fs';
 import * as dotenv from 'dotenv';
 import ErrnoException = NodeJS.ErrnoException;
@@ -53,10 +57,10 @@ const fetchStorylistsPreviewDeckConfig = () =>
                         'title': title,
                         'ordering': previewGridConfig.ordering,
                         'orderInLandingPage': previewGridConfig.landingPageOrder,
-                        'gridTemplateColumns': previewGridConfig.gridTemplateColumns,
-                        'titlePlacement': previewGridConfig.titlePlacement,
-                        'cardsPlacement': previewGridConfig.cardsPlacement[]
-                        {
+                        'previewGridSkeletonConfig': {
+                            'gridTemplateColumns': previewGridConfig.gridTemplateColumns,
+                            'titlePlacement': previewGridConfig.titlePlacement,
+                            'cardsPlacement': previewGridConfig.cardsPlacement[] {
                               'order': order,
                               'slug': @.publication->story->slug.current,
                               'startCol': startCol,
@@ -65,11 +69,27 @@ const fetchStorylistsPreviewDeckConfig = () =>
                               'endCol': endCol,
                               'startRow': startRow,
                               'endRow': endRow,
+                            }
+                        },
+                        'gridSkeletonConfig': {
+                            'gridTemplateColumns': gridConfig.gridTemplateColumns,
+                            'titlePlacement': gridConfig.titlePlacement,
+                            'cardsPlacement': gridConfig.cardsPlacement[] {
+                              'order': order,
+                              'slug': @.publication->story->slug.current,
+                              'startCol': startCol,
+                              'image': image,
+                              'imageSlug': imageSlug.current,
+                              'endCol': endCol,
+                              'startRow': startRow,
+                              'endRow': endRow,
+                            }
                         }
                     } | order (orderInLandingPage asc)`
   );
 
-fetchStorylistsPreviewDeckConfig().then((storylists) => {
+fetchStorylistsPreviewDeckConfig().then((storylists: StorylistDeckConfig[]) => {
+  console.log(storylists);
   // Accede a las variables de entorno y genera un string
   // correspondiente al objeto environment que utilizará Angular
   const environmentFileContent = `
@@ -77,12 +97,15 @@ fetchStorylistsPreviewDeckConfig().then((storylists) => {
        environment: "${environment}",
        contentConfig: ${JSON.stringify(
          storylists
-           .filter((storylist: any) => !!storylist.cardsPlacement)
+           .filter(
+             (storylist: any) =>
+               !!storylist.previewGridSkeletonConfig.cardsPlacement
+           )
            .map((storylist: any) => ({
              ...storylist,
-             amount:
-               storylist.cardsPlacement.filter((card: any) => !!card.slug)
-                 .length,
+             amount: storylist.previewGridSkeletonConfig.cardsPlacement.filter(
+               (card: any) => !!card.slug
+             ).length,
            }))
        )},
        website: "${process.env['CUENTONETA_WEBSITE']}",

--- a/src/app/components/story-list-card-deck/story-list-card-deck.component.ts
+++ b/src/app/components/story-list-card-deck/story-list-card-deck.component.ts
@@ -19,7 +19,7 @@ import {
   StoryList,
 } from '../../models/storylist.model';
 import { APP_ROUTE_TREE } from '../../app-routing.module';
-import {StorylistDeckConfig} from "../../models/content.model";
+import { StorylistGridSkeletonConfig } from "../../models/content.model";
 
 @Component({
   selector: 'cuentoneta-story-list-card-deck',
@@ -34,7 +34,7 @@ export class StoryListCardDeckComponent implements OnInit, OnChanges {
   @Input() isLoading: boolean = false; // Utilizado para mostrar/ocultar skeletons
   @Input() displayTitle: boolean = true;
   @Input() displayFeaturedImage: boolean = false;
-  @Input() skeletonConfig: StorylistDeckConfig | undefined
+  @Input() skeletonConfig: StorylistGridSkeletonConfig | undefined
 
   dummyList: null[] = [];
   imagesCardConfig: { [key: string]: CardDeckCSSGridConfig } = {};

--- a/src/app/models/content.model.ts
+++ b/src/app/models/content.model.ts
@@ -4,12 +4,17 @@ export interface StorylistDeckConfig {
     title: string;
     slug: string;
     ordering: 'asc' | 'desc' | undefined;
-    gridTemplateColumns: string;
     amount: number;
-    titlePlacement: GridItemPlacementConfig,
-    cardsPlacement: GridItemPlacementConfig[];
+    previewGridSkeletonConfig: StorylistGridSkeletonConfig;
+    gridSkeletonConfig: StorylistGridSkeletonConfig;
 }
 
 export interface StorylistCardDeck extends StorylistDeckConfig {
     storylist?: StoryList;
+}
+
+export interface StorylistGridSkeletonConfig {
+    gridTemplateColumns: string;
+    titlePlacement: GridItemPlacementConfig,
+    cardsPlacement: GridItemPlacementConfig[];
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -28,7 +28,7 @@
           [number]="storylistDeck.amount"
           [isLoading]="fetchContentDirective.isLoading"
           [displayFeaturedImage]="true"
-          [skeletonConfig]="storylistDeck"
+          [skeletonConfig]="storylistDeck.previewGridSkeletonConfig"
         ></cuentoneta-story-list-card-deck>
         <ng-container *ngIf="!!storylistDeck.storylist">
           <a

--- a/src/app/pages/story-list/story-list.component.html
+++ b/src/app/pages/story-list/story-list.component.html
@@ -3,5 +3,6 @@
     [displayTitle]="true"
     [storylist]="storylist"
     [isLoading]="fetchContentDirective.isLoading"
+    [skeletonConfig]="skeletonConfig"
   ></cuentoneta-story-list-card-deck>
 </main>


### PR DESCRIPTION
# Resumen
Mejorado el soporte para dibujar skeletons en base a configuración alojada en Sanity, sin necesidad de fetch, generando un objeto de configuración que es asociado a una propiedad en `environment.ts`

## Otros cambios
* Simplificación del modelo `StorylistDeckConfig`.
* Agregadas modificaciones adicionales en `set-environment.ts` para generar archivo `environment.ts` con los layouts de las vistas previas y las listas completas.