### PR TITLE
[#276] Agrega navegación a link original de Story

### DIFF
--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -30,7 +30,6 @@ export default {
             name: 'originalLink',
             title: 'Link Original',
             type: 'string',
-            validation: (Rule) => Rule.required(),
         },
         {
             name: 'approximateReadingTime',

--- a/src/app/components/bio-summary-card/bio-summary-card.component.html
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.html
@@ -32,7 +32,7 @@
         </ng-container>
         <ng-container *ngIf="!!story.originalLink" >
             <a [href]="story.originalLink" target="_blank" class="summary-link flex items-start justify-end gap-3">
-                Link Original
+                Recurso Original
                 <img
                         [ngSrc]="'./assets/svg/external-link.svg'"
                         width="20"

--- a/src/app/components/bio-summary-card/bio-summary-card.component.html
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.html
@@ -1,41 +1,45 @@
 <div class="bio-card-container">
     <section class="author mb-4 sm:mb-8" *ngIf="story.author as author">
         <img
-            class="author-image"
-            width="64"
-            height="64"
-            [alt]="'Retrato de ' + author.name"
-            [ngSrc]="author.imageUrl + '?h=64&w=64'"
+                class="author-image"
+                width="64"
+                height="64"
+                [alt]="'Retrato de ' + author.name"
+                [ngSrc]="author.imageUrl + '?h=64&w=64'"
         />
         <div class="author-info flex flex-col justify-center">
             <p class="author-name">{{ author.name }}</p>
             <div class="author-nationality flex items-center gap-2">
                 <img
-                    class="flag"
-                    width="20"
-                    height="15"
-                    [alt]="'Bandera de ' + author.nationality.country"
-                    [ngSrc]="author.nationality.flag + '?w=20&h=15'"
+                        class="flag"
+                        width="20"
+                        height="15"
+                        [alt]="'Bandera de ' + author.nationality.country"
+                        [ngSrc]="author.nationality.flag + '?w=20&h=15'"
                 />
                 <span>{{ author.nationality.country }}</span>
             </div>
         </div>
-        <a [href]="author.fullBioUrl" target="_blank" class="author-bio-link flex items-start justify-end gap-3">
-            Biografía
-            <img
-                    [ngSrc]="'./assets/svg/external-link.svg'"
-                    width="20"
-                    height="20"
-                    alt="Imagen que representa un link externo"
-            /></a>
-        <a [href]="story.originalLink" target="_blank" class="summary-link flex items-start justify-end gap-3">
-            Link Original
-            <img
-                [ngSrc]="'./assets/svg/external-link.svg'"
-                width="20"
-                height="20"
-                alt="Imagen que representa un link externo"
-        /></a>
+        <ng-container  *ngIf="!!author.fullBioUrl" >
+            <a [href]="author.fullBioUrl" target="_blank" class="author-bio-link flex items-start justify-end gap-3">
+                Biografía
+                <img
+                        [ngSrc]="'./assets/svg/external-link.svg'"
+                        width="20"
+                        height="20"
+                        alt="Imagen que representa un link externo"
+                /></a>
+        </ng-container>
+        <ng-container *ngIf="!!story.originalLink" >
+            <a [href]="story.originalLink" target="_blank" class="summary-link flex items-start justify-end gap-3">
+                Link Original
+                <img
+                        [ngSrc]="'./assets/svg/external-link.svg'"
+                        width="20"
+                        height="20"
+                        alt="Imagen que representa un link externo"
+                /></a>
+        </ng-container>
     </section>
     <section class="bio-and-summary" *ngIf="story.author as author">
         <p>{{ author.biography }}</p>

--- a/src/app/components/bio-summary-card/bio-summary-card.component.html
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.html
@@ -1,5 +1,5 @@
 <div class="bio-card-container">
-    <section class="author-info">
+    <section class="author-info" *ngIf="story.author as author">
         <img
             class="author-image"
             width="64"
@@ -20,6 +20,14 @@
                 <span>{{ author.nationality.country }}</span>
             </div>
         </div>
+        <a [href]="story.originalLink" target="_blank" class="summary-link flex items-start justify-end gap-3">
+            Link Original
+            <img
+                [ngSrc]="'./assets/svg/external-link.svg'"
+                width="20"
+                height="20"
+                alt="Imagen que representa un link externo"
+        /></a>
         <a [href]="author.fullBioUrl" target="_blank" class="author-bio-link flex items-start justify-end gap-3">
             Biografía
             <img
@@ -29,9 +37,9 @@
                 alt="Imagen que representa un link externo"
         /></a>
     </section>
-    <section class="bio-and-summary">
+    <section class="bio-and-summary" *ngIf="story.author as author">
         <p>{{ author.biography }}</p>
-        <ng-container *ngIf="summary">
+        <ng-container *ngIf="story.summary as summary">
             <p [innerHTML]="summary"></p>
         </ng-container>
     </section>

--- a/src/app/components/bio-summary-card/bio-summary-card.component.html
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.html
@@ -1,5 +1,5 @@
 <div class="bio-card-container">
-    <section class="author-info" *ngIf="story.author as author">
+    <section class="author mb-4 sm:mb-8" *ngIf="story.author as author">
         <img
             class="author-image"
             width="64"
@@ -7,7 +7,7 @@
             [alt]="'Retrato de ' + author.name"
             [ngSrc]="author.imageUrl + '?h=64&w=64'"
         />
-        <div class="flex flex-col justify-center">
+        <div class="author-info flex flex-col justify-center">
             <p class="author-name">{{ author.name }}</p>
             <div class="author-nationality flex items-center gap-2">
                 <img
@@ -20,16 +20,16 @@
                 <span>{{ author.nationality.country }}</span>
             </div>
         </div>
-        <a [href]="story.originalLink" target="_blank" class="summary-link flex items-start justify-end gap-3">
-            Link Original
-            <img
-                [ngSrc]="'./assets/svg/external-link.svg'"
-                width="20"
-                height="20"
-                alt="Imagen que representa un link externo"
-        /></a>
         <a [href]="author.fullBioUrl" target="_blank" class="author-bio-link flex items-start justify-end gap-3">
             Biografía
+            <img
+                    [ngSrc]="'./assets/svg/external-link.svg'"
+                    width="20"
+                    height="20"
+                    alt="Imagen que representa un link externo"
+            /></a>
+        <a [href]="story.originalLink" target="_blank" class="summary-link flex items-start justify-end gap-3">
+            Link Original
             <img
                 [ngSrc]="'./assets/svg/external-link.svg'"
                 width="20"

--- a/src/app/components/bio-summary-card/bio-summary-card.component.scss
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.scss
@@ -18,7 +18,7 @@
                 grid-row: row / span 2;
             }
 
-            .author-bio-link {
+            .author-bio-link, .summary-link {
                 grid-column: col 2 / span 1;
                 grid-row: row 2;
                 justify-content: center;
@@ -26,7 +26,7 @@
         }
 
         @media screen and (min-width: $min-sm-width) {
-            grid-template-columns: $spacing-16 1fr $spacing-32;
+            grid-template-columns: $spacing-16 1fr $spacing-36 $spacing-32;
         }
 
         column-gap: $spacing-4;
@@ -49,7 +49,7 @@
             }
         }
 
-        .author-bio-link {
+        .author-bio-link, .summary-link {
             @include inter-body-base-semibold;
             color: $interactive-500;
         }

--- a/src/app/components/bio-summary-card/bio-summary-card.component.scss
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.scss
@@ -6,22 +6,34 @@
     border-radius: $rounded;
     padding: $spacing-6;
 
-    .author-info {
+    .author {
         display: grid;
 
         @media screen and (max-width: $max-xs-width) {
-            grid-template-columns: [col] $spacing-16 [col] 1fr;
+            grid-template-columns: [col] $spacing-16 [col] 1fr [col] 1fr [col] $spacing-16 ;
             grid-template-rows: [row] auto [row] auto;
+            row-gap: $spacing-4;
 
             .author-image {
                 grid-column: col / span 1;
-                grid-row: row / span 2;
+                grid-row: row / span 1;
             }
 
-            .author-bio-link, .summary-link {
-                grid-column: col 2 / span 1;
+            .author-info {
+                grid-column: col 2 / span 3;
+                grid-row: row / span 1;
+            }
+
+            .author-bio-link{
+                grid-column: col 1 / span 2;
                 grid-row: row 2;
-                justify-content: center;
+                justify-content: left;
+            }
+
+            .summary-link{
+                grid-column: col 3 / span 2;
+                grid-row: row 2;
+                justify-content: left;
             }
         }
 
@@ -30,7 +42,6 @@
         }
 
         column-gap: $spacing-4;
-        margin-bottom: $spacing-8;
 
         .author-image {
             border-radius: $rounded-md;

--- a/src/app/components/bio-summary-card/bio-summary-card.component.ts
+++ b/src/app/components/bio-summary-card/bio-summary-card.component.ts
@@ -1,20 +1,21 @@
+// Core
 import { Component, Input } from '@angular/core';
-import { Author } from '../../models/author.model';
 import { NgOptimizedImage, NgIf, CommonModule } from '@angular/common';
 
+// Modelos
+import { Story } from '@models/story.model';
+
 @Component({
-    selector: 'cuentoneta-bio-summary-card[author]',
+    selector: 'cuentoneta-bio-summary-card',
     templateUrl: './bio-summary-card.component.html',
     styleUrls: ['./bio-summary-card.component.scss'],
     standalone: true,
     imports: [
-        CommonModule, 
-        NgOptimizedImage, 
+        CommonModule,
+        NgOptimizedImage,
         NgIf
     ],
 })
 export class BioSummaryCardComponent {
-    // @ts-ignore
-    @Input() author: Author;
-    @Input() summary: string | undefined;
+    @Input({required: true}) story!: Story;
 }

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -7,6 +7,7 @@ export interface StoryBase {
     slug: string;
     approximateReadingTime: number;
     author: Author;
+    originalLink: string;
 }
 
 export interface Story extends StoryBase {

--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -7,7 +7,7 @@ export interface StoryBase {
     slug: string;
     approximateReadingTime: number;
     author: Author;
-    originalLink: string;
+    originalLink?: string;
 }
 
 export interface Story extends StoryBase {

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -63,11 +63,7 @@
 
     <footer>
       <ng-container *ngIf="!!story && !fetchContentDirective.isLoading">
-        <cuentoneta-bio-summary-card
-                *ngIf="story?.author?.biography"
-                [author]="story.author"
-                [summary]="story.summary"
-        />
+        <cuentoneta-bio-summary-card [story]="story"/>
       </ng-container>
     </footer>
   </article>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,10 @@
         "noImplicitOverride": true,
         "noPropertyAccessFromIndexSignature": true,
         "noImplicitReturns": true,
-        "noFallthroughCasesInSwitch": true
+        "noFallthroughCasesInSwitch": true,
+        "paths": {
+            "@models/*": ["src/app/models/*"]
+        },
     },
     "files": [],
     "include": [],


### PR DESCRIPTION
# Descripción
* Agrega link externo para redirigir a usuario a la ubicación del recurso original del cual tomamos la historia presentada.
* Mejora el diseño responsive para acomodar la información referida a cada autor `BioSummaryCardComponent`.
* Elimina validación `required` para el campo `originalLink` en el schema `Story`.
* Agrega render condicional para links de recurso original y bio completa.