### PR TITLE
[#352] - Generación de link para compartir en Whatsapp en vista Story

### DIFF
--- a/src/app/components/share-content/share-content.component.ts
+++ b/src/app/components/share-content/share-content.component.ts
@@ -91,7 +91,7 @@ class WhatsappPlatform implements SharingPlatform {
     urlParams: string,
     message: string
   ): string {
-    const sharedUrl = encodeURIComponent(`${environment.website}${appRoute}?${urlParams}`);
+    const sharedUrl = encodeURIComponent(`${environment.website}/${appRoute}?${urlParams}`);
     const queryParams: { [key: string]: string } = {
       text: `${message}%0a%0a${sharedUrl}`,
     };

--- a/src/app/components/share-content/share-content.component.ts
+++ b/src/app/components/share-content/share-content.component.ts
@@ -91,7 +91,7 @@ class WhatsappPlatform implements SharingPlatform {
     urlParams: string,
     message: string
   ): string {
-    const sharedUrl = `${environment.website}/${appRoute}?${urlParams}`;
+    const sharedUrl = encodeURIComponent(`${environment.website}${appRoute}?${urlParams}`);
     const queryParams: { [key: string]: string } = {
       text: `${message}%0a%0a${sharedUrl}`,
     };


### PR DESCRIPTION
# Resumen
Corregido el encoding de URLs para compartir stories por WhatsApp.