### PR TITLE
[#341] Agrega navegación a Storylist al clickear en título de preview

### DIFF
--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -19,7 +19,16 @@
             'grid-column-end': storylist.gridConfig?.titlePlacement?.endCol,
           }"
       >
-        <h1 class="title">{{ storylist.title }}</h1>
+        <h1 class="title">
+          <a
+            [ngClass]="{ 'nav-link': canNavigateToStorylist }"
+            [routerLink]="
+              canNavigateToStorylist ? '/' + appRouteTree['STORYLIST'] : null
+            "
+            [queryParams]="{ slug: storylist.slug }"
+            >{{ storylist.title }}</a
+          >
+        </h1>
         <h3 class="subtitle">{{ storylist.description }}</h3>
       </div>
     </ng-container>
@@ -98,7 +107,7 @@
           'grid-column-end': skeleton?.endCol,
           }"
         [theme]="{
-          'height': '100%',
+          height: '100%',
           width: '100%',
           'background-color': '#D4D4D8'
         }"

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.scss
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.scss
@@ -4,6 +4,10 @@ $cards-grid-gap: $spacing-8;
 
 .title {
   margin-bottom: $spacing-5;
+
+  > .nav-link:hover {
+    color: $interactive-500;
+  }
 }
 
 .subtitle{

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.ts
@@ -37,6 +37,7 @@ export class StorylistCardDeckComponent implements OnInit, OnChanges {
   @Input() number: number = 6;
   @Input() storylist: Storylist | undefined;
   @Input() isLoading: boolean = false; // Utilizado para mostrar/ocultar skeletons
+  @Input() canNavigateToStorylist: boolean = false;
   @Input() displayTitle: boolean = true;
   @Input() displayFeaturedImage: boolean = false;
   @Input() skeletonConfig: StorylistGridSkeletonConfig | undefined

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -23,6 +23,7 @@
       <ng-container *ngFor="let storylistDeck of storylistCardDecks">
         <cuentoneta-storylist-card-deck
           class="mb-3"
+          [canNavigateToStorylist]="true"
           [storylist]="storylistDeck.storylist"
           [displayTitle]="true"
           [number]="storylistDeck.amount"


### PR DESCRIPTION
# Resumen
* Agrega comportamiento habitual de link al hacer hover en el título de un `StorylistCardDeckComponent` cuando el nuevo input `canNavigateToStorylist` está puesto en `true`.
* Implementa `canNavigateToStorylist` en true para las instancias de `StorylistCardDeckComponent` declaradas en `HomeComponent`.