### PR TITLE
[#288] Mejoras en barra de navegación de storylist

### DIFF
--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.html
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.html
@@ -1,7 +1,10 @@
 <section>
   <header>
     <ng-container *ngIf="storylist && storylist.title; else titleSkeleton">
-      <a [routerLink]="'/' + appRouteTree['STORYLIST']" [queryParams]="{ slug: storylist.slug }">
+      <a
+        [routerLink]="'/' + appRouteTree['STORYLIST']"
+        [queryParams]="{ slug: storylist.slug }"
+      >
         <h3 class="storylist-title">{{ storylist.title }}</h3>
       </a>
     </ng-container>
@@ -15,7 +18,7 @@
         "
         [queryParams]="{ slug: publication.story.slug, list: storylist.slug }"
       >
-        <article>
+        <article [ngClass]="{ 'selected': selectedStorySlug === publication.story.slug }">
           <cuentoneta-story-edition-date-label
             class="edition-and-label"
             [label]="
@@ -38,7 +41,10 @@
   <!-- ToDo: #288 - Generar abstracción para evitar repetir lógica presente en el header (ver líneas 2 - 9)-->
   <footer *ngIf="storylist && storylist.publications.length > 10">
     <ng-container *ngIf="storylist; else titleSkeleton">
-      <a [routerLink]="'/' + appRouteTree['STORYLIST']" [queryParams]="{ slug: storylist.slug }">
+      <a
+        [routerLink]="'/' + appRouteTree['STORYLIST']"
+        [queryParams]="{ slug: storylist.slug }"
+      >
         <h3 class="storylist-title">Ver más...</h3>
       </a>
     </ng-container>

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.html
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.html
@@ -11,7 +11,7 @@
   </header>
 
   <ng-container *ngIf="!!storylist; else bodySkeleton">
-    <ng-container *ngFor="let publication of storylist.publications">
+    <ng-container *ngFor="let publication of displayedPublications">
       <a
         [routerLink]="
           publication.published ? ['/' + appRouteTree['STORY']] : null
@@ -39,7 +39,7 @@
   </ng-container>
 
   <!-- ToDo: #288 - Generar abstracción para evitar repetir lógica presente en el header (ver líneas 2 - 9)-->
-  <footer *ngIf="storylist && storylist.publications.length > 10">
+  <footer *ngIf="storylist && storylist.publications.length >= 10">
     <ng-container *ngIf="storylist; else titleSkeleton">
       <a
         [routerLink]="'/' + appRouteTree['STORYLIST']"

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.scss
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.scss
@@ -26,6 +26,12 @@ section {
     grid-row-gap: 2px;
 
     article {
+
+        &.selected {
+            border-left: 4px solid $primary-400;
+            background-color: $primary-100;
+        }
+
         @include card-spacing;
         background-color: $gray-50;
 

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.ts
@@ -1,36 +1,49 @@
-import { Component, Input } from '@angular/core';
-import { Publication, Storylist } from '../../models/storylist.model';
-import { Story } from '../../models/story.model';
+import { Component, inject, Input } from '@angular/core';
+import { Publication, Storylist } from '@models/storylist.model';
+import { Story } from '@models/story.model';
 import { APP_ROUTE_TREE } from '../../app-routing.module';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { StoryEditionDateLabelComponent } from '../story-edition-date-label/story-edition-date-label.component';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { NgIf, NgFor, CommonModule } from '@angular/common';
+import { combineLatest, of, switchMap } from 'rxjs';
 
 @Component({
-    selector: 'cuentoneta-story-navigation-bar',
-    templateUrl: './story-navigation-bar.component.html',
-    styleUrls: ['./story-navigation-bar.component.scss'],
-    standalone: true,
-    imports: [
-        CommonModule,
-        NgxSkeletonLoaderModule,
-        NgIf,
-        NgFor,
-        RouterLink,
-        StoryEditionDateLabelComponent,
-        StoryNavigationBarComponent
-    ],
+  selector: 'cuentoneta-story-navigation-bar',
+  templateUrl: './story-navigation-bar.component.html',
+  styleUrls: ['./story-navigation-bar.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    NgxSkeletonLoaderModule,
+    NgIf,
+    NgFor,
+    RouterLink,
+    StoryEditionDateLabelComponent,
+    StoryNavigationBarComponent,
+  ],
 })
 export class StoryNavigationBarComponent {
-    @Input() storylist!: Storylist;
+  @Input() storylist!: Storylist;
 
-    readonly appRouteTree = APP_ROUTE_TREE;
-    dummyList: null[] = Array(10);
+  readonly appRouteTree = APP_ROUTE_TREE;
+  dummyList: null[] = Array(10);
+  selectedStorySlug: string = '';
 
-    // ToDo: Separar card de cada cuento de la lista en su propio componente, para evitar usar un método en el template
-    getEditionLabel(publication: Publication<Story>, editionIndex: number = 0): string {
-        return `${this.storylist?.editionPrefix} ${editionIndex} ${this.storylist.displayDates ? ' - ' + publication.publishingDate : ''
-            }`;
-    }
+  constructor() {
+    const activatedRoute = inject(ActivatedRoute);
+    activatedRoute.queryParams.subscribe(
+      ({ slug, list }) => (this.selectedStorySlug = slug)
+    );
+  }
+
+  // ToDo: Separar card de cada cuento de la lista en su propio componente, para evitar usar un método en el template
+  getEditionLabel(
+    publication: Publication<Story>,
+    editionIndex: number = 0
+  ): string {
+    return `${this.storylist?.editionPrefix} ${editionIndex} ${
+      this.storylist.displayDates ? ' - ' + publication.publishingDate : ''
+    }`;
+  }
 }

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -1,5 +1,6 @@
 <aside class="hidden md:block">
   <cuentoneta-story-navigation-bar
+          [selectedStorySlug]="story?.slug ?? ''"
           [storylist]="storylist"
   ></cuentoneta-story-navigation-bar>
 </aside>

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -9,8 +9,8 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { APP_ROUTE_TREE } from '../../app-routing.module';
 
 // Models
-import { Story } from '../../models/story.model';
-import { Storylist } from '../../models/storylist.model';
+import { Story } from '@models/story.model';
+import { Storylist } from '@models/storylist.model';
 
 // Services
 import { MacroTaskWrapperService } from '../../providers/macro-task-wrapper.service';
@@ -86,6 +86,7 @@ export class StoryComponent {
     content$.subscribe(([story, storylist]) => {
       this.story = story;
       this.storylist = storylist;
+
       metaTagsDirective.setTitle(
         `${story.title}, de ${story.author.name} en La Cuentoneta`
       );


### PR DESCRIPTION
# Resumen
* Agregados estilos para destacar en navbar la story actualmente en vista
* Limitada la cantidad de stories visibles en la navbar a 10, utilizando como pivot la story actualmente en vista. El método `sliceDisplayedPublications` intenta obtener las cinco historias anteriores y posteriores a la actual seleccionada dentro de la storylist, ajustando los límites en caso de que la story actual sea de las primeras o últimas de la storylist.