### PR TITLE
[#368] Agregar ambiente staging en Vercel

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,5 +36,5 @@
       "rules": {}
     }
   ],
-  "extends": [null, "plugin:storybook/recommended"]
+  "extends": ["plugin:storybook/recommended"]
 }

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -43,7 +43,7 @@ const generateApiUrl = (
   }
   // Lectura de la variable de entorno de Vercel para deployments de preview
   else if (environment === 'preview') {
-    url = `https://${process.env['VERCEL_URL']}` as string;
+    url = `https://${process.env['VERCEL_URL']}/` as string;
   }
 
   return url;
@@ -116,7 +116,7 @@ fetchStorylistsPreviewDeckConfig().then((storylists: StorylistDeckConfig[]) => {
            }))
        )},
        website: "${process.env['CUENTONETA_WEBSITE']}",
-       apiUrl: "${apiUrl}}"
+       apiUrl: "${apiUrl}"
     };
 `;
 

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -53,7 +53,7 @@ const generateApiUrl = (
 const environment: TEnvironmentType =
   (process.env['VERCEL_ENV'] as TEnvironmentType) ?? 'development';
 
-const branchUrl: string = process.env['VERCEL_BRANCH_URL'];
+const branchUrl: string = process.env['VERCEL_BRANCH_URL'] as string;
 const stagingBranchUrl = 'cuentoneta-git-develop-rolivencia.vercel.app';
 
 const apiUrl = generateApiUrl(environment, branchUrl);

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -29,11 +29,6 @@ dotenv.config();
 
 const dirPath: string = `src/app/environments`;
 const targetPath = `${dirPath}/environment.ts`;
-const environment: TEnvironmentType =
-  (process.env['VERCEL_ENV'] as TEnvironmentType) ?? 'development';
-
-const branchUrl: string = process.env['VERCEL_BRANCH_URL'];
-const stagingBranchUrl = 'cuentoneta-git-develop-rolivencia.vercel.app';
 
 // Genera una ruta absoluta a la API en función del ambiente
 const generateApiUrl = (
@@ -53,6 +48,15 @@ const generateApiUrl = (
 
   return url;
 };
+
+// Constantes para generar el archivo de environment
+const environment: TEnvironmentType =
+  (process.env['VERCEL_ENV'] as TEnvironmentType) ?? 'development';
+
+const branchUrl: string = process.env['VERCEL_BRANCH_URL'];
+const stagingBranchUrl = 'cuentoneta-git-develop-rolivencia.vercel.app';
+
+const apiUrl = generateApiUrl(environment, branchUrl);
 
 // Obtiene la vista de preview para generar skeletons
 const fetchStorylistsPreviewDeckConfig = () =>
@@ -112,7 +116,7 @@ fetchStorylistsPreviewDeckConfig().then((storylists: StorylistDeckConfig[]) => {
            }))
        )},
        website: "${process.env['CUENTONETA_WEBSITE']}",
-       apiUrl: "${generateApiUrl(environment, branchUrl)}"
+       apiUrl: "${apiUrl}}"
     };
 `;
 
@@ -140,6 +144,7 @@ fetchStorylistsPreviewDeckConfig().then((storylists: StorylistDeckConfig[]) => {
         'URL de branch de Vercel - VERCEL_BRANCH_URL = ',
         process.env['VERCEL_BRANCH_URL']
       );
+      console.log('URL de API = ', apiUrl);
     }
   );
 });

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -32,20 +32,23 @@ const targetPath = `${dirPath}/environment.ts`;
 const environment: TEnvironmentType =
   (process.env['VERCEL_ENV'] as TEnvironmentType) ?? 'development';
 
-console.log('VERCEL_ENV', process.env['VERCEL_ENV']);
-console.log('VERCEL_BRANCH_URL', process.env['VERCEL_BRANCH_URL']);
+const branchUrl: string = process.env['VERCEL_BRANCH_URL'];
+const stagingBranchUrl = 'cuentoneta-git-develop-rolivencia.vercel.app';
 
 // Genera una ruta absoluta a la API en función del ambiente
-const generateApiUrl = (environment: TEnvironmentType): string => {
+const generateApiUrl = (
+  environment: TEnvironmentType,
+  branchUrl: string
+): string => {
   let url = '';
 
-  // Lectura de la variable de entorno de Vercel para deployments de preview
-  if (environment === 'preview' || environment === 'staging') {
-    url = `https://${process.env['VERCEL_URL']}/` as string;
-  }
-
-  if (environment === 'production') {
+  // Asigna URL en base a variables de entorno para producción y staging (preview develop)
+  if (environment === 'production' || branchUrl === stagingBranchUrl) {
     url = process.env['CUENTONETA_WEBSITE'] as string;
+  }
+  // Lectura de la variable de entorno de Vercel para deployments de preview
+  else if (environment === 'preview') {
+    url = `https://${process.env['VERCEL_URL']}/` as string;
   }
 
   return url;
@@ -109,7 +112,7 @@ fetchStorylistsPreviewDeckConfig().then((storylists: StorylistDeckConfig[]) => {
            }))
        )},
        website: "${process.env['CUENTONETA_WEBSITE']}",
-       apiUrl: "${generateApiUrl(environment)}"
+       apiUrl: "${generateApiUrl(environment, branchUrl)}"
     };
 `;
 
@@ -129,6 +132,14 @@ fetchStorylistsPreviewDeckConfig().then((storylists: StorylistDeckConfig[]) => {
         return;
       }
       console.log(`Variables de entorno escritas en ${targetPath}`);
+      console.log(
+        'Ambiente de Vercel - VERCEL_ENV = ',
+        process.env['VERCEL_ENV']
+      );
+      console.log(
+        'URL de branch de Vercel - VERCEL_BRANCH_URL = ',
+        process.env['VERCEL_BRANCH_URL']
+      );
     }
   );
 });

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -43,7 +43,7 @@ const generateApiUrl = (
   }
   // Lectura de la variable de entorno de Vercel para deployments de preview
   else if (environment === 'preview') {
-    url = `https://${process.env['VERCEL_URL']}/` as string;
+    url = `https://${process.env['VERCEL_URL']}` as string;
   }
 
   return url;

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -27,7 +27,7 @@ type TEnvironmentType = 'development' | 'preview' | 'staging' | 'production';
 // Leer variables de entorno desde .env
 dotenv.config();
 
-const dirPath: string = `src/app/environments`;
+const dirPath = `src/app/environments`;
 const targetPath = `${dirPath}/environment.ts`;
 
 // Genera una ruta absoluta a la API en función del ambiente

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -32,6 +32,9 @@ const targetPath = `${dirPath}/environment.ts`;
 const environment: TEnvironmentType =
   (process.env['VERCEL_ENV'] as TEnvironmentType) ?? 'development';
 
+console.log('VERCEL_ENV', process.env['VERCEL_ENV']);
+console.log('VERCEL_BRANCH_URL', process.env['VERCEL_BRANCH_URL']);
+
 // Genera una ruta absoluta a la API en función del ambiente
 const generateApiUrl = (environment: TEnvironmentType): string => {
   let url = '';


### PR DESCRIPTION
# Resumen
* Agregados cambios en script `set-environment.ts` para ajustar apiUrl en el ambiente de staging.
* Agrega impresión en consola de constantes relevantes para facilitar el debugging al hacer deploy.

## Otros cambios
* Corrección en archivo de configuración de ESLint que generaba problemas al ejecutar la herramienta.