### PR TITLE
[#359] - Agregar propiedad url a schema story

### DIFF
--- a/cms/schemas/story.ts
+++ b/cms/schemas/story.ts
@@ -32,6 +32,11 @@ export default {
             type: 'string',
         },
         {
+            name: 'videoUrl',
+            title: 'URL del video con lectura/recitado del cuento',
+            type: 'url',
+        },
+        {
             name: 'approximateReadingTime',
             title: 'Tiempo de lectura aproximado',
             type: 'computedNumber',

--- a/src/api/story.service.ts
+++ b/src/api/story.service.ts
@@ -1,5 +1,5 @@
 import { client } from './_helpers/sanity-connector';
-import { mapAuthor, mapPrologues, urlFor } from './_utils/functions';
+import { mapAuthor, mapPrologues } from './_utils/functions';
 
 async function fetchForRead(req: any, res: any) {
   {
@@ -9,6 +9,7 @@ async function fetchForRead(req: any, res: any) {
                               'slug':slug.current,
                               title, 
                               originalLink, 
+                              videoUrl,
                               forewords, 
                               categories, 
                               body, 

--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -38,6 +38,7 @@ async function fetchPreview(req: express.Request, res: express.Response) {
                                             'slug': slug.current,
                                             title,
                                             originalLink,
+                                            videoUrl,
                                             forewords,
                                             categories,
                                             body[0...3],


### PR DESCRIPTION
# Resumen
* Agrega campo `videoUrl` al schema `story` en Sanity.
* Agrega propiedad `videoUrl` en los endpoints de la API para
  * `story` en `story.service.ts`
  * `storylist` en  `story.service.ts`