### PR TITLE
[#359] - Agregar soporte para cuentos en formato video

### DIFF
--- a/src/app/models/story.model.ts
+++ b/src/app/models/story.model.ts
@@ -8,6 +8,7 @@ export interface StoryBase {
     approximateReadingTime: number;
     author: Author;
     originalLink?: string;
+    videoUrl?: string;
 }
 
 export interface Story extends StoryBase {

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -34,7 +34,7 @@
       <iframe
         *ngIf="story.videoUrl != null"
         class="video mb-6 sm:mb-10"
-        [src]="story.videoUrl"
+        [src]="sanitizerUrl(story.videoUrl)"
         title="YouTube video player"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/src/app/pages/story/story.component.html
+++ b/src/app/pages/story/story.component.html
@@ -1,7 +1,7 @@
 <aside class="hidden md:block">
   <cuentoneta-story-navigation-bar
-          [selectedStorySlug]="story?.slug ?? ''"
-          [storylist]="storylist"
+    [selectedStorySlug]="story?.slug ?? ''"
+    [storylist]="storylist"
   ></cuentoneta-story-navigation-bar>
 </aside>
 <main>
@@ -9,15 +9,15 @@
     <header class="flex flex-col-reverse sm:block mb-6 sm:mb-10">
       <aside class="sm:float-right mt-6 sm:ml-12 sm:mb-12 sm:mt-0">
         <cuentoneta-share-content
-                [isLoading]="fetchContentDirective.isLoading"
-                [params]="shareContentParams"
-                [route]="appRouteTree['STORY']"
-                [message]="shareMessage"
+          [isLoading]="fetchContentDirective.isLoading"
+          [params]="shareContentParams"
+          [route]="appRouteTree['STORY']"
+          [message]="shareMessage"
         />
       </aside>
       <div>
         <ng-container
-                *ngIf="
+          *ngIf="
             !!story && !fetchContentDirective.isLoading;
             else titleSkeleton
           "
@@ -30,20 +30,31 @@
         </ng-container>
       </div>
     </header>
+    <ng-container *ngIf="!!story && !fetchContentDirective.isLoading">
+      <iframe
+        *ngIf="story.videoUrl != null"
+        class="video mb-6 sm:mb-10"
+        [src]="story.videoUrl"
+        title="YouTube video player"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowfullscreen
+      ></iframe>
+    </ng-container>
 
     <ng-container *ngIf="!!story && !fetchContentDirective.isLoading">
       <section
-              class="prologues flex"
-              *ngIf="!!story.prologues && story.prologues.length > 0"
+        class="prologues flex"
+        *ngIf="!!story.prologues && story.prologues.length > 0"
       >
         <ng-container *ngFor="let prologue of story.prologues">
           <div class="bar"></div>
           <p class="prologue flex flex-col md:flex-row md:items-center">
             {{ prologue.text }}&nbsp;<em
-                  class="self-end"
-                  *ngIf="prologue.reference"
-          >{{ prologue.reference }}</em
-          >
+              class="self-end"
+              *ngIf="prologue.reference"
+              >{{ prologue.reference }}</em
+            >
           </p>
         </ng-container>
       </section>
@@ -51,7 +62,7 @@
 
     <section class="content">
       <ng-container
-              *ngIf="
+        *ngIf="
           !!story && !fetchContentDirective.isLoading;
           else contentSkeleton
         "
@@ -64,7 +75,7 @@
 
     <footer>
       <ng-container *ngIf="!!story && !fetchContentDirective.isLoading">
-        <cuentoneta-bio-summary-card [story]="story"/>
+        <cuentoneta-bio-summary-card [story]="story" />
       </ng-container>
     </footer>
   </article>
@@ -72,27 +83,27 @@
 
 <ng-template #titleSkeleton>
   <ngx-skeleton-loader
-          count="1"
-          appearance="line"
-          [theme]="{
+    count="1"
+    appearance="line"
+    [theme]="{
       'height.px': 36,
       'background-color': '#D4D4D8',
       width: '50%'
     }"
   ></ngx-skeleton-loader>
   <ngx-skeleton-loader
-          count="1"
-          appearance="line"
-          [theme]="{
+    count="1"
+    appearance="line"
+    [theme]="{
       'height.px': 20,
       'background-color': '#D4D4D8',
       width: '25%'
     }"
   ></ngx-skeleton-loader>
   <ngx-skeleton-loader
-          count="1"
-          appearance="line"
-          [theme]="{
+    count="1"
+    appearance="line"
+    [theme]="{
       'height.px': 16,
       'background-color': '#D4D4D8',
       width: '20%'

--- a/src/app/pages/story/story.component.scss
+++ b/src/app/pages/story/story.component.scss
@@ -65,6 +65,11 @@ article {
     }
   }
 
+  .video {
+    aspect-ratio: 16 / 9;
+    width: 100%;
+  }
+
   footer {
   }
 }

--- a/src/app/pages/story/story.component.ts
+++ b/src/app/pages/story/story.component.ts
@@ -24,6 +24,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { StoryNavigationBarComponent } from 'src/app/components/story-navigation-bar/story-navigation-bar.component';
 import { BioSummaryCardComponent } from 'src/app/components/bio-summary-card/bio-summary-card.component';
 import { ShareContentComponent } from 'src/app/components/share-content/share-content.component';
+import { DomSanitizer } from '@angular/platform-browser';
 
 @Component({
   selector: 'cuentoneta-story',
@@ -39,7 +40,7 @@ import { ShareContentComponent } from 'src/app/components/share-content/share-co
     ShareContentComponent
   ],
   hostDirectives: [
-    FetchContentDirective,
+    FetchContentDirective, 
     MetaTagsDirective,
   ],
 })
@@ -53,6 +54,8 @@ export class StoryComponent {
   dummyList = Array(10);
   shareContentParams: { [key: string]: string } = {};
   shareMessage: string = '';
+
+  private sanitizer: DomSanitizer = inject(DomSanitizer);
 
   constructor() {
     const platformId = inject(PLATFORM_ID);
@@ -77,11 +80,11 @@ export class StoryComponent {
     const content$ = isPlatformBrowser(platformId)
       ? fetchObservable$
       : macroTaskWrapperService.wrapMacroTaskObservable<[Story, Storylist]>(
-        'StoryComponent.fetchData',
-        fetchObservable$,
-        null,
-        'first-emit'
-      );
+          'StoryComponent.fetchData',
+          fetchObservable$,
+          null,
+          'first-emit'
+        );
 
     content$.subscribe(([story, storylist]) => {
       this.story = story;
@@ -96,5 +99,16 @@ export class StoryComponent {
       this.shareContentParams = { slug: story.slug, list: storylist.slug };
       this.shareMessage = `Leí "${story.title}" de ${story.author.name} en La Cuentoneta y te lo comparto. Sumate a leer este y otros cuentos de la colección "${storylist.title}" en este link:`;
     });
+  }
+
+  // sanitizerUrl = this.story.videoUrl ? this.sanitizer.bypassSecurityTrustResourceUrl(
+  //   this.story.videoUrl): undefined;
+
+  sanitizerUrl(url: string) {
+    if (url) {
+      return this.sanitizer.bypassSecurityTrustResourceUrl(url);
+    } else {
+      return undefined;
+    }
   }
 }


### PR DESCRIPTION
# Resumen
 *  Agrega propiedad `videoUrl`, de tipo `string` y opcional, al modelo `StoryBase` en `story.model.ts`. 
 * Implementa el tag `<iframe>` dentro de `StoryComponent` para poder visualizar contenido.


 ## Otros cambios
 * Agrega clase `video` y define estilos en `story.model.scss` para que el renderizado sea responsive.