### PR TITLE
[#404] - Agrega propiedad videoUrl en endpoints de storylist service

### DIFF
--- a/src/api/storylist.service.ts
+++ b/src/api/storylist.service.ts
@@ -46,6 +46,7 @@ async function fetchPreview(req: express.Request, res: express.Response) {
                                             review,
                                             forewords,
                                             approximateReadingTime,
+                                            videoUrl,
                                             'author': author-> { name, image, nationality-> }
                                         }
                                     }
@@ -152,6 +153,7 @@ async function fetchStorylist(req: any, res: any) {
                                         review,
                                         forewords,
                                         approximateReadingTime,
+                                        videoUrl,
                                         'author': author-> { name, image, nationality-> }
                                     }
                                 }


### PR DESCRIPTION
# Resumen
Agrega propiedad videoUrl en endpoint `fetchStorylist` y `fetchStorylistPreview`, incluidos en el archivo `storylist.service.ts`