### PR TITLE
[#243] - Mejoras de accesibilidad

### DIFF
--- a/src/app/components/story-card/story-card.component.html
+++ b/src/app/components/story-card/story-card.component.html
@@ -1,4 +1,4 @@
-<article class="p-5 md:p-8 flex gap-2 md:gap-4">
+<article class="p-5 md:p-8 flex gap-2 md:gap-4" [attr.aria-busy]="!publication">
   <ng-container *ngIf="!!publication && publication.published; else skeleton">
     <ng-container *ngIf="publication.story as story">
       <header class="card-header">

--- a/src/app/components/story-card/story-card.component.html
+++ b/src/app/components/story-card/story-card.component.html
@@ -7,7 +7,7 @@
         />
       </header>
       <section>
-        <h1 class="card-title">{{ story.title }}</h1>
+        <h2 class="card-title">{{ story.title }}</h2>
         <p
           class="content "
           [innerHTML]="previewText"

--- a/src/app/components/story-edition-date-label/story-edition-date-label.component.html
+++ b/src/app/components/story-edition-date-label/story-edition-date-label.component.html
@@ -1,6 +1,6 @@
-<label class="date" *ngIf="!!label"
+<span class="date" *ngIf="!!label"
     ><div class="rect"></div>
     {{label}}
-</label>
+</span>
 <!--ToDo: Extraer badge a nuevo componente-->
 <div class="badge-new" *ngIf="markAsNew"><label>NUEVO</label></div>

--- a/src/app/components/story-navigation-bar/story-navigation-bar.component.html
+++ b/src/app/components/story-navigation-bar/story-navigation-bar.component.html
@@ -1,5 +1,5 @@
 <section>
-  <header>
+  <header [attr.aria-busy]="!storylist">
     <ng-container *ngIf="storylist && storylist.title; else titleSkeleton">
       <a
         [routerLink]="'/' + appRouteTree['STORYLIST']"
@@ -71,7 +71,7 @@
 </ng-template>
 
 <ng-template #bodySkeleton>
-  <article *ngFor="let skeleton of dummyList">
+  <article [attr.aria-busy]="true" *ngFor="let skeleton of dummyList">
     <ngx-skeleton-loader count="2" appearance="line"></ngx-skeleton-loader>
   </article>
 </ng-template>

--- a/src/app/components/storylist-card-deck/storylist-card-deck.component.html
+++ b/src/app/components/storylist-card-deck/storylist-card-deck.component.html
@@ -1,11 +1,12 @@
-<div
+<article
   class="stories-card-container"
+  [attr.aria-busy]="!storylist"
   [ngStyle]="{
     'grid-template-columns': storylist?.gridConfig?.gridTemplateColumns
   }"
 >
   <ng-container *ngTemplateOutlet="storylistTemplate"> </ng-container>
-</div>
+</article>
 
 <ng-template #storylistTemplate>
   <!-- Renderizado de título y descripción -->


### PR DESCRIPTION
# Resumen
Este PR aborda todos los ítems faltantes de implementación listados en #243:

- Cambio de tags h1 por h2 en títulos de cards.
- Cambio de atributo lang de la página desde `en` a `es`
- Agregado de aria-label para URLs de banderas e imágenes alusivas a autores
- Agregado de `aria-busy=true` al mostrar skeletons
- Cambio de tag `label` a `span` para leyenda y números de historia en `StoryCardComponent`